### PR TITLE
feat(Kandel): Introduce PushAndSupplyKandel

### DIFF
--- a/script/strategies/kandel/KandelPopulate.s.sol
+++ b/script/strategies/kandel/KandelPopulate.s.sol
@@ -5,7 +5,7 @@ import {Script, console2 as console} from "forge-std/Script.sol";
 import {Kandel, IERC20, IMangrove, OfferType} from "mgv_src/strategies/offer_maker/market_making/kandel/Kandel.sol";
 import {CoreKandel} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/CoreKandel.sol";
 import {AbstractKandel} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/AbstractKandel.sol";
-import {LongKandel} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/LongKandel.sol";
+import {GeometricKandel} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/GeometricKandel.sol";
 
 import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
 import {Deployer} from "mgv_script/lib/Deployer.sol";
@@ -23,7 +23,7 @@ import {KandelLib} from "mgv_lib/kandel/KandelLib.sol";
 
 contract KandelPopulate is Deployer {
   function run() public {
-    LongKandel kdl = Kandel(envAddressOrName("KANDEL"));
+    Kandel kdl = Kandel(envAddressOrName("KANDEL"));
     Kandel.Params memory params;
     params.ratio = uint24(vm.envUint("RATIO"));
     require(params.ratio == vm.envUint("RATIO"), "Invalid RATIO");
@@ -64,7 +64,7 @@ contract KandelPopulate is Deployer {
     Kandel.Params params;
     uint initQuote;
     uint volume;
-    LongKandel kdl;
+    Kandel kdl;
     MgvReader mgvReader;
   }
 
@@ -195,7 +195,7 @@ contract KandelPopulate is Deployer {
     vars.snapshotId = vm.snapshot();
     vm.startPrank(broadcaster());
     (vars.pivotIds, vars.baseAmountRequired, vars.quoteAmountRequired) = KandelLib.estimatePivotsAndRequiredAmount(
-      distribution, LongKandel(args.kdl), args.firstAskIndex, args.params, funds
+      distribution, GeometricKandel(args.kdl), args.firstAskIndex, args.params, funds
     );
     vm.stopPrank();
     require(vm.revertTo(vars.snapshotId), "snapshot restore failed");

--- a/script/strategies/kandel/KandelShutdown.s.sol
+++ b/script/strategies/kandel/KandelShutdown.s.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.13;
 
 import {Script, console2 as console} from "forge-std/Script.sol";
+import {GeometricKandel} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/GeometricKandel.sol";
 import {LongKandel} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/LongKandel.sol";
 import {OfferType} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/TradesBaseQuotePair.sol";
 import {IERC20} from "mgv_src/IERC20.sol";
@@ -14,10 +15,10 @@ import {Deployer} from "mgv_script/lib/Deployer.sol";
 
 contract KandelShutdown is Deployer {
   function run() public {
-    innerRun({kdl: LongKandel(envAddressOrName("KANDEL"))});
+    innerRun({kdl: GeometricKandel(envAddressOrName("KANDEL"))});
   }
 
-  function innerRun(LongKandel kdl) public {
+  function innerRun(GeometricKandel kdl) public {
     IERC20 base = kdl.BASE();
     IERC20 quote = kdl.QUOTE();
     uint baseDecimals = base.decimals();
@@ -31,8 +32,9 @@ contract KandelShutdown is Deployer {
     uint baseAmount = kdl.reserveBalance(OfferType.Ask); // base balance
     uint quoteAmount = kdl.reserveBalance(OfferType.Bid); // quote balance
 
+    LongKandel longKandel = LongKandel(address(kdl));
     broadcast();
-    kdl.retractAndWithdraw(0, length, baseAmount, quoteAmount, type(uint).max, payable(broadcaster()));
+    longKandel.retractAndWithdraw(0, length, baseAmount, quoteAmount, type(uint).max, payable(broadcaster()));
 
     baseBalance = base.balanceOf(broadcaster()) - baseBalance;
     quoteBalance = quote.balanceOf(broadcaster()) - quoteBalance;
@@ -52,7 +54,7 @@ contract KandelShutdown is Deployer {
     baseAmount = (pendingBase > 0 ? uint(pendingBase) : 0);
     quoteAmount = (pendingQuote > 0 ? uint(pendingQuote) : 0);
     broadcast();
-    kdl.withdrawFunds(baseAmount, quoteAmount, broadcaster());
+    longKandel.withdrawFunds(baseAmount, quoteAmount, broadcaster());
 
     console.log(
       "Retrieved %s base and %s quote tokens", toFixed(baseAmount, baseDecimals), toFixed(quoteAmount, quoteDecimals)

--- a/src/strategies/MangroveOffer.sol
+++ b/src/strategies/MangroveOffer.sol
@@ -8,6 +8,10 @@ import {IMangrove} from "mgv_src/IMangrove.sol";
 import {AbstractRouter} from "mgv_src/strategies/routers/AbstractRouter.sol";
 import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
 
+abstract contract AbstractMangroveOffer is IOfferLogic {
+  function withdrawFromMangrove(uint amount, address payable receiver) public virtual;
+}
+
 /// @title This contract is the basic building block for Mangrove strats.
 /// @notice It contains the mandatory interface expected by Mangrove (`IOfferLogic` is `IMaker`) and enforces additional functions implementations (via `IOfferLogic`).
 /// @dev Naming scheme:
@@ -15,7 +19,7 @@ import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
 /// `_f() internal`: descendant of this contract should provide a public wrapper for this function, with necessary guards.
 /// `__f__() virtual internal`: descendant of this contract should override this function to specialize it to the needs of the strat.
 
-abstract contract MangroveOffer is AccessControlled, IOfferLogic {
+abstract contract MangroveOffer is AccessControlled, AbstractMangroveOffer {
   ///@notice Gas requirement when posting offers via this strategy, excluding router requirement.
   uint public immutable OFFER_GASREQ;
   ///@notice The Mangrove deployment that is allowed to call `this` for trade execution and posthook.
@@ -188,7 +192,7 @@ abstract contract MangroveOffer is AccessControlled, IOfferLogic {
   }
 
   /// @inheritdoc IOfferLogic
-  function withdrawFromMangrove(uint amount, address payable receiver) public onlyAdmin {
+  function withdrawFromMangrove(uint amount, address payable receiver) public override onlyAdmin {
     if (amount == type(uint).max) {
       amount = MGV.balanceOf(address(this));
     }

--- a/src/strategies/offer_maker/market_making/kandel/AaveKandel.sol
+++ b/src/strategies/offer_maker/market_making/kandel/AaveKandel.sol
@@ -6,16 +6,14 @@ import {MgvLib} from "mgv_src/MgvLib.sol";
 import {AbstractRouter, AavePooledRouter} from "mgv_src/strategies/routers/integrations/AavePooledRouter.sol";
 import {IATokenIsh} from "mgv_src/strategies/vendor/aave/v3/IATokenIsh.sol";
 import {LongKandel} from "./abstract/LongKandel.sol";
+import {PushAndSupplyKandel} from "./abstract/PushAndSupplyKandel.sol";
 import {AbstractKandel} from "./abstract/AbstractKandel.sol";
 import {OfferType} from "./abstract/TradesBaseQuotePair.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
 import {IERC20} from "mgv_src/IERC20.sol";
 
 ///@title A Kandel strat with geometric price progression which stores funds on AAVE to generate yield.
-contract AaveKandel is LongKandel {
-  ///@notice Indication that this is first puller (returned from __lastLook__) so posthook should deposit liquidity on AAVE
-  bytes32 internal constant IS_FIRST_PULLER = "IS_FIRST_PULLER";
-
+contract AaveKandel is PushAndSupplyKandel, LongKandel {
   ///@notice Constructor
   ///@param mgv The Mangrove deployment.
   ///@param base Address of the base token of the market Kandel will act on
@@ -24,39 +22,9 @@ contract AaveKandel is LongKandel {
   ///@param gasprice the gasprice to use for offers
   ///@param reserveId identifier of this contract's reserve when using a router.
   constructor(IMangrove mgv, IERC20 base, IERC20 quote, uint gasreq, uint gasprice, address reserveId)
-    LongKandel(mgv, base, quote, gasreq, gasprice, reserveId)
-  {
-    // one makes sure it is not possible to deploy an AAVE kandel on aTokens
-    // allowing Kandel to deposit aUSDC for instance would conflict with other Kandel instances bound to the same router
-    // and trading on USDC.
-    // The code below verifies that neither base nor quote are official AAVE overlyings.
-    bool isOverlying;
-    try IATokenIsh(address(base)).UNDERLYING_ASSET_ADDRESS() returns (address) {
-      isOverlying = true;
-    } catch {}
-    try IATokenIsh(address(quote)).UNDERLYING_ASSET_ADDRESS() returns (address) {
-      isOverlying = true;
-    } catch {}
-    require(!isOverlying, "AaveKandel/cannotTradeAToken");
-  }
-
-  ///@notice returns the router as an Aave router
-  ///@return AavePooledRouter cast
-  function pooledRouter() private view returns (AavePooledRouter) {
-    AbstractRouter router_ = router();
-    require(router_ != NO_ROUTER, "AaveKandel/uninitialized");
-    return AavePooledRouter(address(router_));
-  }
-
-  ///@notice Sets the AaveRouter as router and activates router for base and quote
-  ///@param router_ the Aave router to use.
-  function initialize(AavePooledRouter router_) external onlyAdmin {
-    setRouter(router_);
-    // calls below will fail if router's admin has not bound router to `this`. We call __activate__ instead of activate just to save gas.
-    __activate__(BASE);
-    __activate__(QUOTE);
-    setGasreq(offerGasreq());
-  }
+    PushAndSupplyKandel(mgv, base, quote, gasreq, gasprice, reserveId)
+    LongKandel(base, quote)
+  {}
 
   ///@notice Deposits funds to the contract's reserve
   ///@param baseAmount the amount of base tokens to deposit.
@@ -65,7 +33,7 @@ contract AaveKandel is LongKandel {
     // transfer funds from caller to this
     super.depositFunds(baseAmount, quoteAmount);
     // push funds on the router (and supply on AAVE)
-    pooledRouter().pushAndSupply(BASE, baseAmount, QUOTE, quoteAmount, RESERVE_ID);
+    pushAndSupplyRouter().pushAndSupply(BASE, baseAmount, QUOTE, quoteAmount, RESERVE_ID);
   }
 
   ///@notice withdraws base and quote from the contract's reserve
@@ -74,49 +42,11 @@ contract AaveKandel is LongKandel {
   ///@param recipient the address to which the withdrawn funds should be sent to.
   function withdrawFunds(uint baseAmount, uint quoteAmount, address recipient) public override onlyAdmin {
     if (baseAmount != 0) {
-      pooledRouter().withdraw(BASE, RESERVE_ID, baseAmount);
+      AavePooledRouter(address(pushAndSupplyRouter())).withdraw(BASE, RESERVE_ID, baseAmount);
     }
     if (quoteAmount != 0) {
-      pooledRouter().withdraw(QUOTE, RESERVE_ID, quoteAmount);
+      AavePooledRouter(address(pushAndSupplyRouter())).withdraw(QUOTE, RESERVE_ID, quoteAmount);
     }
     super.withdrawFunds(baseAmount, quoteAmount, recipient);
-  }
-
-  ///@notice returns the amount of the router's balance that belong to this contract for the token offered for the offer type.
-  ///@inheritdoc AbstractKandel
-  function reserveBalance(OfferType ba) public view override returns (uint balance) {
-    IERC20 token = outboundOfOfferType(ba);
-    return router().balanceOfReserve(token, RESERVE_ID) + super.reserveBalance(ba);
-  }
-
-  /// @notice Verifies, prior to pulling funds from the router, whether pull will be fetching funds on AAVE
-  /// @inheritdoc MangroveOffer
-  function __lastLook__(MgvLib.SingleOrder calldata order) internal override returns (bytes32) {
-    bytes32 makerData = super.__lastLook__(order);
-    return (IERC20(order.outbound_tkn).balanceOf(address(router())) < order.wants) ? IS_FIRST_PULLER : makerData;
-  }
-
-  ///@notice overrides and replaces Direct's posthook in order to push and supply on AAVE with a single call when offer logic is the first to pull funds from AAVE
-  ///@inheritdoc MangroveOffer
-  function __posthookSuccess__(MgvLib.SingleOrder calldata order, bytes32 makerData)
-    internal
-    override
-    returns (bytes32 repostStatus)
-  {
-    // handle dual offer posting
-    transportSuccessfulOrder(order);
-
-    // handles pushing back liquidity to the router
-    if (makerData == IS_FIRST_PULLER) {
-      // if first puller, then router should deposit liquidity on AAVE
-      pooledRouter().pushAndSupply(
-        BASE, BASE.balanceOf(address(this)), QUOTE, QUOTE.balanceOf(address(this)), RESERVE_ID
-      );
-      // reposting offer residual if any - but do not call super, since Direct will flush tokens unnecessarily
-      repostStatus = MangroveOffer.__posthookSuccess__(order, makerData);
-    } else {
-      // reposting offer residual if any - call super to let flush tokens to router
-      repostStatus = super.__posthookSuccess__(order, makerData);
-    }
   }
 }

--- a/src/strategies/offer_maker/market_making/kandel/Kandel.sol
+++ b/src/strategies/offer_maker/market_making/kandel/Kandel.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.10;
 
 import {MangroveOffer} from "mgv_src/strategies/MangroveOffer.sol";
+import {GeometricKandel} from "./abstract/GeometricKandel.sol";
 import {LongKandel} from "./abstract/LongKandel.sol";
 import {AbstractKandel} from "./abstract/AbstractKandel.sol";
 import {OfferType} from "./abstract/TradesBaseQuotePair.sol";
@@ -10,7 +11,7 @@ import {IERC20} from "mgv_src/IERC20.sol";
 import {MgvLib} from "mgv_src/MgvLib.sol";
 
 ///@title The Kandel strat with geometric price progression.
-contract Kandel is LongKandel {
+contract Kandel is GeometricKandel, LongKandel {
   ///@notice Constructor
   ///@param mgv The Mangrove deployment.
   ///@param base Address of the base token of the market Kandel will act on
@@ -19,7 +20,8 @@ contract Kandel is LongKandel {
   ///@param gasprice the gasprice to use for offers
   ///@param reserveId identifier of this contract's reserve when using a router.
   constructor(IMangrove mgv, IERC20 base, IERC20 quote, uint gasreq, uint gasprice, address reserveId)
-    LongKandel(mgv, base, quote, gasreq, gasprice, reserveId)
+    GeometricKandel(mgv, base, quote, gasreq, gasprice, reserveId)
+    LongKandel(base, quote)
   {
     // since we won't add a router later, we can activate the strat now.  We call __activate__ instead of activate just to save gas.
     __activate__(BASE);

--- a/src/strategies/offer_maker/market_making/kandel/ShortKandel.sol
+++ b/src/strategies/offer_maker/market_making/kandel/ShortKandel.sol
@@ -5,17 +5,14 @@ import {MangroveOffer} from "mgv_src/strategies/MangroveOffer.sol";
 import {MgvLib} from "mgv_src/MgvLib.sol";
 import {AbstractRouter, AavePrivateRouter} from "mgv_src/strategies/routers/integrations/AavePrivateRouter.sol";
 import {IATokenIsh} from "mgv_src/strategies/vendor/aave/v3/IATokenIsh.sol";
-import {GeometricKandel} from "./abstract/GeometricKandel.sol";
+import {PushAndSupplyKandel} from "./abstract/PushAndSupplyKandel.sol";
 import {AbstractKandel} from "./abstract/AbstractKandel.sol";
 import {OfferType} from "./abstract/TradesBaseQuotePair.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
 import {IERC20} from "mgv_src/IERC20.sol";
 
 ///@title A Kandel strat which posts offers on base/quote and quote/base offer lists with geometric price progression which stores funds on AAVE to generate yield.
-contract ShortKandel is GeometricKandel {
-  ///@notice Indication that this is first puller (returned from __lastLook__) so posthook should deposit liquidity on AAVE
-  bytes32 internal constant IS_FIRST_PULLER = "IS_FIRST_PULLER";
-
+contract ShortKandel is PushAndSupplyKandel {
   ///@notice Constructor
   ///@param mgv The Mangrove deployment.
   ///@param base Address of the base token of the market Kandel will act on
@@ -24,39 +21,8 @@ contract ShortKandel is GeometricKandel {
   ///@param gasprice the gasprice to use for offers
   ///@param reserveId identifier of this contract's reserve when using a router.
   constructor(IMangrove mgv, IERC20 base, IERC20 quote, uint gasreq, uint gasprice, address reserveId)
-    GeometricKandel(mgv, base, quote, gasreq, gasprice, reserveId)
-  {
-    // one makes sure it is not possible to deploy an AAVE kandel on aTokens
-    // allowing Kandel to deposit aUSDC for instance would conflict with other Kandel instances bound to the same router
-    // and trading on USDC.
-    // The code below verifies that neither base nor quote are official AAVE overlyings.
-    bool isOverlying;
-    try IATokenIsh(address(base)).UNDERLYING_ASSET_ADDRESS() returns (address) {
-      isOverlying = true;
-    } catch {}
-    try IATokenIsh(address(quote)).UNDERLYING_ASSET_ADDRESS() returns (address) {
-      isOverlying = true;
-    } catch {}
-    require(!isOverlying, "ShortKandel/cannotTradeAToken");
-  }
-
-  ///@notice returns the router as an Aave private router
-  ///@return AavePrivateRouter cast
-  function privateRouter() private view returns (AavePrivateRouter) {
-    AbstractRouter router_ = router();
-    require(router_ != NO_ROUTER, "ShortKandel/uninitialized");
-    return AavePrivateRouter(address(router_));
-  }
-
-  ///@notice Sets the AaveRouter as router and activates router for base and quote
-  ///@param router_ the Aave router to use.
-  function initialize(AavePrivateRouter router_) external onlyAdmin {
-    setRouter(router_);
-    // calls below will fail if router's admin has not bound router to `this`. We call __activate__ instead of activate just to save gas.
-    __activate__(BASE);
-    __activate__(QUOTE);
-    setGasreq(offerGasreq());
-  }
+    PushAndSupplyKandel(mgv, base, quote, gasreq, gasprice, reserveId)
+  {}
 
   ///@notice publishes bids/asks for the distribution in the `indices`. Caller should follow the desired distribution in `baseDist` and `quoteDist`.
   ///@param distribution the distribution of base and quote for Kandel indices
@@ -88,7 +54,7 @@ contract ShortKandel is GeometricKandel {
   ///@param amount to deposit
   function depositFunds(IERC20 token, uint amount) external onlyAdmin {
     _deposit(token, amount);
-    privateRouter().pushAndSupply(token, amount, IERC20(address(0)), 0);
+    pushAndSupplyRouter().pushAndSupply(token, amount, IERC20(address(0)), 0, RESERVE_ID);
   }
 
   ///@notice withdraws funds from the contract's reserve
@@ -100,41 +66,5 @@ contract ShortKandel is GeometricKandel {
       router().pull(token, RESERVE_ID, amount, true);
     }
     _withdraw(token, amount, recipient);
-  }
-
-  ///@notice returns the amount of the router's balance that belong to this contract for the token offered for the offer type.
-  ///@inheritdoc AbstractKandel
-  function reserveBalance(OfferType ba) public view override returns (uint balance) {
-    IERC20 token = outboundOfOfferType(ba);
-    return router().balanceOfReserve(token, RESERVE_ID) + super.reserveBalance(ba);
-  }
-
-  /// @notice Verifies, prior to pulling funds from the router, whether pull will be fetching funds on AAVE
-  /// @inheritdoc MangroveOffer
-  function __lastLook__(MgvLib.SingleOrder calldata order) internal override returns (bytes32) {
-    bytes32 makerData = super.__lastLook__(order);
-    return (IERC20(order.outbound_tkn).balanceOf(address(router())) < order.wants) ? IS_FIRST_PULLER : makerData;
-  }
-
-  ///@notice overrides and replaces Direct's posthook in order to push and supply on AAVE with a single call when offer logic is the first to pull funds from AAVE
-  ///@inheritdoc MangroveOffer
-  function __posthookSuccess__(MgvLib.SingleOrder calldata order, bytes32 makerData)
-    internal
-    override
-    returns (bytes32 repostStatus)
-  {
-    // handle dual offer posting
-    transportSuccessfulOrder(order);
-
-    // handles pushing back liquidity to the router
-    if (makerData == IS_FIRST_PULLER) {
-      // if first puller, then router should deposit liquidity on AAVE
-      privateRouter().pushAndSupply(BASE, BASE.balanceOf(address(this)), QUOTE, QUOTE.balanceOf(address(this)));
-      // reposting offer residual if any - but do not call super, since Direct will flush tokens unnecessarily
-      repostStatus = MangroveOffer.__posthookSuccess__(order, makerData);
-    } else {
-      // reposting offer residual if any - call super to let flush tokens to router
-      repostStatus = super.__posthookSuccess__(order, makerData);
-    }
   }
 }

--- a/src/strategies/offer_maker/market_making/kandel/abstract/DirectWithBidsAndAsksDistribution.sol
+++ b/src/strategies/offer_maker/market_making/kandel/abstract/DirectWithBidsAndAsksDistribution.sol
@@ -7,8 +7,16 @@ import {OfferType} from "./TradesBaseQuotePair.sol";
 import {HasIndexedBidsAndAsks} from "./HasIndexedBidsAndAsks.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
 
+abstract contract AbstractDirectWithBidsAndAsksDistribution {
+  function retractOffers(uint from, uint to) public virtual;
+}
+
 ///@title `Direct` strat with an indexed collection of bids and asks which can be populated according to a desired base and quote distribution for gives and wants.
-abstract contract DirectWithBidsAndAsksDistribution is Direct, HasIndexedBidsAndAsks {
+abstract contract DirectWithBidsAndAsksDistribution is
+  Direct,
+  HasIndexedBidsAndAsks,
+  AbstractDirectWithBidsAndAsksDistribution
+{
   ///@notice The offer has too low volume to be posted.
   bytes32 internal constant LOW_VOLUME = "Kandel/volumeTooLow";
 
@@ -138,7 +146,7 @@ abstract contract DirectWithBidsAndAsksDistribution is Direct, HasIndexedBidsAnd
   ///@param from the start index.
   ///@param to the end index.
   ///@dev use in conjunction of `withdrawFromMangrove` if the user wishes to redeem the available WEIs.
-  function retractOffers(uint from, uint to) public onlyAdmin {
+  function retractOffers(uint from, uint to) public override onlyAdmin {
     emit RetractStart();
     (IERC20 outbound_tknAsk, IERC20 inbound_tknAsk) = tokenPairOfOfferType(OfferType.Ask);
     (IERC20 outbound_tknBid, IERC20 inbound_tknBid) = (inbound_tknAsk, outbound_tknAsk);

--- a/src/strategies/offer_maker/market_making/kandel/abstract/PushAndSupplyKandel.sol
+++ b/src/strategies/offer_maker/market_making/kandel/abstract/PushAndSupplyKandel.sol
@@ -1,0 +1,98 @@
+// SPDX-License-Identifier:	BSD-2-Clause
+pragma solidity ^0.8.10;
+
+import {MangroveOffer} from "mgv_src/strategies/MangroveOffer.sol";
+import {MgvLib} from "mgv_src/MgvLib.sol";
+import {AbstractRouter, PushAndSupplyRouter} from "mgv_src/strategies/routers/integrations/PushAndSupplyRouter.sol";
+import {IATokenIsh} from "mgv_src/strategies/vendor/aave/v3/IATokenIsh.sol";
+import {GeometricKandel} from "./GeometricKandel.sol";
+import {AbstractKandel} from "./AbstractKandel.sol";
+import {OfferType} from "./TradesBaseQuotePair.sol";
+import {IMangrove} from "mgv_src/IMangrove.sol";
+import {IERC20} from "mgv_src/IERC20.sol";
+
+///@title A Kandel strat which posts offers on base/quote and quote/base offer lists with geometric price progression and uses a push-and-supply router.
+contract PushAndSupplyKandel is GeometricKandel {
+  ///@notice Indication that this is first puller (returned from __lastLook__) so posthook should deposit liquidity on AAVE
+  bytes32 internal constant IS_FIRST_PULLER = "IS_FIRST_PULLER";
+
+  ///@notice Constructor
+  ///@param mgv The Mangrove deployment.
+  ///@param base Address of the base token of the market Kandel will act on
+  ///@param quote Address of the quote token of the market Kandel will act on
+  ///@param gasreq the gasreq to use for offers
+  ///@param gasprice the gasprice to use for offers
+  ///@param reserveId identifier of this contract's reserve when using a router.
+  constructor(IMangrove mgv, IERC20 base, IERC20 quote, uint gasreq, uint gasprice, address reserveId)
+    GeometricKandel(mgv, base, quote, gasreq, gasprice, reserveId)
+  {
+    // one makes sure it is not possible to deploy an AAVE kandel on aTokens
+    // allowing Kandel to deposit aUSDC for instance would conflict with other Kandel instances bound to the same router
+    // and trading on USDC.
+    // The code below verifies that neither base nor quote are official AAVE overlyings.
+    bool isOverlying;
+    try IATokenIsh(address(base)).UNDERLYING_ASSET_ADDRESS() returns (address) {
+      isOverlying = true;
+    } catch {}
+    try IATokenIsh(address(quote)).UNDERLYING_ASSET_ADDRESS() returns (address) {
+      isOverlying = true;
+    } catch {}
+    require(!isOverlying, "PushAndSupplyKandel/cannotTradeAToken");
+  }
+
+  ///@notice returns the router as an Aave private router
+  ///@return PushAndSupplyRouter cast
+  function pushAndSupplyRouter() internal view returns (PushAndSupplyRouter) {
+    AbstractRouter router_ = router();
+    require(router_ != NO_ROUTER, "PushAndSupplyKandel/uninitialized");
+    return PushAndSupplyRouter(address(router_));
+  }
+
+  ///@notice Sets the PushAndSupplyRouter as router and activates router for base and quote
+  ///@param router_ the Aave router to use.
+  function initialize(PushAndSupplyRouter router_) external onlyAdmin {
+    setRouter(router_);
+    // calls below will fail if router's admin has not bound router to `this`. We call __activate__ instead of activate just to save gas.
+    __activate__(BASE);
+    __activate__(QUOTE);
+    setGasreq(offerGasreq());
+  }
+
+  ///@notice returns the amount of the router's balance that belong to this contract for the token offered for the offer type.
+  ///@inheritdoc AbstractKandel
+  function reserveBalance(OfferType ba) public view override returns (uint balance) {
+    IERC20 token = outboundOfOfferType(ba);
+    return router().balanceOfReserve(token, RESERVE_ID) + super.reserveBalance(ba);
+  }
+
+  /// @notice Verifies, prior to pulling funds from the router, whether pull will be fetching funds on AAVE
+  /// @inheritdoc MangroveOffer
+  function __lastLook__(MgvLib.SingleOrder calldata order) internal override returns (bytes32) {
+    bytes32 makerData = super.__lastLook__(order);
+    return (IERC20(order.outbound_tkn).balanceOf(address(router())) < order.wants) ? IS_FIRST_PULLER : makerData;
+  }
+
+  ///@notice overrides and replaces Direct's posthook in order to push and supply on AAVE with a single call when offer logic is the first to pull funds from AAVE
+  ///@inheritdoc MangroveOffer
+  function __posthookSuccess__(MgvLib.SingleOrder calldata order, bytes32 makerData)
+    internal
+    override
+    returns (bytes32 repostStatus)
+  {
+    // handle dual offer posting
+    transportSuccessfulOrder(order);
+
+    // handles pushing back liquidity to the router
+    if (makerData == IS_FIRST_PULLER) {
+      // if first puller, then router should deposit liquidity on AAVE
+      pushAndSupplyRouter().pushAndSupply(
+        BASE, BASE.balanceOf(address(this)), QUOTE, QUOTE.balanceOf(address(this)), RESERVE_ID
+      );
+      // reposting offer residual if any - but do not call super, since Direct will flush tokens unnecessarily
+      repostStatus = MangroveOffer.__posthookSuccess__(order, makerData);
+    } else {
+      // reposting offer residual if any - call super to let flush tokens to router
+      repostStatus = super.__posthookSuccess__(order, makerData);
+    }
+  }
+}

--- a/src/strategies/routers/integrations/AavePooledRouter.sol
+++ b/src/strategies/routers/integrations/AavePooledRouter.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.10;
 
 import {AbstractRouter} from "../AbstractRouter.sol";
+import {PushAndSupplyRouter} from "./PushAndSupplyRouter.sol";
 import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
 import {HasAaveBalanceMemoizer} from "./HasAaveBalanceMemoizer.sol";
 import {IERC20} from "mgv_src/IERC20.sol";
@@ -19,7 +20,7 @@ import {IERC20} from "mgv_src/IERC20.sol";
 ///    * `__pull__`  checks whether local balance of token is below required amount. If so it pulls all its funds from AAVE (this includes funds that do not belong to the owner of the calling contract) and sends to caller all the owner's reserve (according to the shares attributed to the owner - except in case of liquidity sharing where only requested amount is transferred). This router then decreases owner's shares accordingly. (note that if AAVE has no liquidity crisis, then the owner's shares will be temporarily 0)
 ///    * `__push__` transfers the requested amount of tokens from the calling maker contract and increases owner's shares, but does not supply on AAVE
 
-contract AavePooledRouter is HasAaveBalanceMemoizer, AbstractRouter {
+contract AavePooledRouter is HasAaveBalanceMemoizer, PushAndSupplyRouter {
   ///@notice the manager which controls which pools are allowed.
   address public aaveManager;
 
@@ -64,7 +65,7 @@ contract AavePooledRouter is HasAaveBalanceMemoizer, AbstractRouter {
   ///@param overhead is the amount of gas that is required for this router to be able to perform a `pull` and a `push`.
   constructor(address addressesProvider, uint overhead)
     HasAaveBalanceMemoizer(addressesProvider)
-    AbstractRouter(overhead)
+    PushAndSupplyRouter(overhead)
   {
     setAaveManager(msg.sender);
   }
@@ -202,6 +203,7 @@ contract AavePooledRouter is HasAaveBalanceMemoizer, AbstractRouter {
   ///@dev this function is also to be used when user deposits funds on the maker contract
   function pushAndSupply(IERC20 token0, uint amount0, IERC20 token1, uint amount1, address reserveId)
     external
+    override
     onlyBound
     returns (uint pushed0, uint pushed1)
   {

--- a/src/strategies/routers/integrations/PushAndSupplyRouter.sol
+++ b/src/strategies/routers/integrations/PushAndSupplyRouter.sol
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier:	BSD-2-Clause
+pragma solidity ^0.8.10;
+
+import {AbstractRouter} from "../AbstractRouter.sol";
+import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
+import {AaveMemoizer, ReserveConfiguration} from "./AaveMemoizer.sol";
+import {IERC20} from "mgv_src/IERC20.sol";
+
+abstract contract PushAndSupplyRouter is AbstractRouter {
+  ///@notice contract's constructor
+  ///@param overhead is the amount of gas that is required for this router to be able to perform a `pull` and a `push`.
+  ///@dev `msg.sender` will be admin of this router
+  constructor(uint overhead) AbstractRouter(overhead) {}
+
+  function pushAndSupply(IERC20 token0, uint amount0, IERC20 token1, uint amount1, address reserveId)
+    external
+    virtual
+    returns (uint pushed0, uint pushed1);
+}

--- a/test/strategies/kandel/Long/LongKandel.t.sol
+++ b/test/strategies/kandel/Long/LongKandel.t.sol
@@ -5,9 +5,8 @@ import {MgvStructs} from "mgv_src/MgvLib.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
 import {TestToken} from "mgv_test/lib/tokens/TestToken.sol";
 import {Kandel, OfferType, IERC20} from "mgv_src/strategies/offer_maker/market_making/kandel/Kandel.sol";
-import {
-  LongKandel, GeometricKandel
-} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/LongKandel.sol";
+import {LongKandel} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/LongKandel.sol";
+import {GeometricKandel} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/GeometricKandel.sol";
 import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
 import {KandelLib} from "lib/kandel/KandelLib.sol";
 import {GeometricKandelTest} from "../abstract/GeometricKandel.t.sol";
@@ -59,7 +58,7 @@ contract LongKandelTest is GeometricKandelTest {
   function deployOtherKandel(uint base0, uint quote0, uint24 ratio, uint8 spread, uint8 pricePoints) internal {
     address otherMaker = freshAddress();
 
-    LongKandel otherKandel = LongKandel($(__deployKandel__(otherMaker, otherMaker)));
+    GeometricKandel otherKandel = GeometricKandel($(__deployKandel__(otherMaker, otherMaker)));
 
     vm.prank(otherMaker);
     TransferLib.approveToken(base, address(otherKandel), type(uint).max);
@@ -95,7 +94,7 @@ contract LongKandelTest is GeometricKandelTest {
     deal($(quote), otherMaker, pendingQuote);
 
     vm.prank(otherMaker);
-    otherKandel.depositFunds(pendingBase, pendingQuote);
+    LongKandel(address(otherKandel)).depositFunds(pendingBase, pendingQuote);
   }
 
   function retractDefaultSetup() internal {
@@ -289,7 +288,7 @@ contract LongKandelTest is GeometricKandelTest {
     t.snapshotId = vm.snapshot();
     vm.startPrank(maker);
     (t.pivotIds, t.baseAmountRequired, t.quoteAmountRequired) =
-      KandelLib.estimatePivotsAndRequiredAmount(distribution, LongKandel($(kdl)), t.firstAskIndex, params, t.funds);
+      KandelLib.estimatePivotsAndRequiredAmount(distribution, GeometricKandel($(kdl)), t.firstAskIndex, params, t.funds);
     vm.stopPrank();
     require(vm.revertTo(t.snapshotId), "snapshot restore failed");
 

--- a/test/strategies/kandel/Short/ShortKandel.gas.t.sol
+++ b/test/strategies/kandel/Short/ShortKandel.gas.t.sol
@@ -3,9 +3,10 @@ pragma solidity ^0.8.10;
 
 import {GeometricKandelGasTest, PinnedPolygonFork, MgvReader, IMangrove} from "../abstract/GeometricKandel.gas.t.sol";
 import {TestToken} from "mgv_test/lib/tokens/TestToken.sol";
-import {
-  ShortKandel, GeometricKandel, IERC20
-} from "mgv_src/strategies/offer_maker/market_making/kandel/ShortKandel.sol";
+import {ShortKandel} from "mgv_src/strategies/offer_maker/market_making/kandel/ShortKandel.sol";
+import {IERC20} from "mgv_src/IERC20.sol";
+import {GeometricKandel} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/GeometricKandel.sol";
+
 import {AavePrivateRouter} from "mgv_src/strategies/routers/integrations/AavePrivateRouter.sol";
 
 contract ShortKandelGasTest is GeometricKandelGasTest {

--- a/test/strategies/kandel/Short/ShortKandel.t.sol
+++ b/test/strategies/kandel/Short/ShortKandel.t.sol
@@ -5,12 +5,10 @@ import {MgvStructs, MgvLib} from "mgv_src/MgvLib.sol";
 import {IMangrove} from "mgv_src/IMangrove.sol";
 import {TestToken} from "mgv_test/lib/tokens/TestToken.sol";
 import {MgvReader} from "mgv_src/periphery/MgvReader.sol";
-import {
-  ShortKandel,
-  GeometricKandel,
-  OfferType,
-  IERC20
-} from "mgv_src/strategies/offer_maker/market_making/kandel/ShortKandel.sol";
+import {ShortKandel, OfferType} from "mgv_src/strategies/offer_maker/market_making/kandel/ShortKandel.sol";
+import {IERC20} from "mgv_src/IERC20.sol";
+import {GeometricKandel} from "mgv_src/strategies/offer_maker/market_making/kandel/abstract/GeometricKandel.sol";
+
 import {TransferLib} from "mgv_src/strategies/utils/TransferLib.sol";
 import {KandelLib} from "lib/kandel/KandelLib.sol";
 import {GeometricKandelTest} from "../abstract/GeometricKandel.t.sol";


### PR DESCRIPTION
PoC of taking out commonality of AaveKandel and ShortKandel into a PushAndSupplyKandel which pulls funds at first offer in chain (via a PushAndSupplyRouter) and pushes it back in posthook.

To do this I had to introduce some pseudo-interfaces (Abstract contracts) because solidity interfaces do not work for anything but external functions and these are internal calls. 

Similar work could be done to extract logic from AavePrivateRouter and AavePooledRouter. Benefit is less code (fewer places for bugs and less to audit), but at the risk of becoming convoluted.
