### PR TITLE
Feat/ratioastick

### DIFF
--- a/lib/kandel/KandelLib.sol
+++ b/lib/kandel/KandelLib.sol
@@ -5,9 +5,10 @@ import {CoreKandel, OfferType} from "mgv_strat_src/strategies/offer_maker/market
 import {GeometricKandel} from "mgv_strat_src/strategies/offer_maker/market_making/kandel/abstract/GeometricKandel.sol";
 import {MgvStructs} from "mgv_src/MgvLib.sol";
 import {IERC20} from "mgv_src/IERC20.sol";
+import {LogPriceLib} from "mgv_lib/LogPriceLib.sol";
 
 library KandelLib {
-  function calculateDistribution(uint from, uint to, uint initBase, uint initQuote, uint ratio, uint precision)
+  function calculateDistribution(uint from, uint to, uint initBase, uint initQuote, uint logPriceOffset)
     internal
     pure
     returns (CoreKandel.Distribution memory vars, uint lastQuote)
@@ -20,8 +21,8 @@ library KandelLib {
       vars.indices[i] = from;
       vars.baseDist[i] = initBase;
       vars.quoteDist[i] = initQuote;
-      // the ratio gives the price difference between two price points - the spread is involved when calculating the jump between a bid and its dual ask.
-      initQuote = (initQuote * uint(ratio)) / (10 ** precision);
+      // the logPriceOffset gives the price difference between two price points - the spread is involved when calculating the jump between a bid and its dual ask.
+      initQuote = (initQuote * LogPriceLib.inboundFromOutbound(int(logPriceOffset), 1 ether)) / 1 ether;
       ++i;
     }
     return (vars, initQuote);

--- a/script/strategies/kandel/KandelPopulate.s.sol
+++ b/script/strategies/kandel/KandelPopulate.s.sol
@@ -21,7 +21,7 @@ import {OLKey} from "mgv_src/MgvLib.sol";
 
 /**
  * KANDEL=Kandel_WETH_USDC FROM=0 TO=100 FIRST_ASK_INDEX=50 PRICE_POINTS=100\
- *    RATIO=101 SPREAD=1 INIT_QUOTE=$(cast ff 6 100) VOLUME=$(cast ff 18 0.1)\
+ *    LOG_PRICE_OFFSET=769 SPREAD=1 INIT_QUOTE=$(cast ff 6 100) VOLUME=$(cast ff 18 0.1)\
  *    forge script KandelPopulate --fork-url $LOCALHOST_URL --private-key $MUMBAI_PRIVATE_KEY --broadcast
  */
 
@@ -29,8 +29,8 @@ contract KandelPopulate is Deployer {
   function run() public {
     GeometricKandel kdl = Kandel(envAddressOrName("KANDEL"));
     Kandel.Params memory params;
-    params.ratio = uint24(vm.envUint("RATIO"));
-    require(params.ratio == vm.envUint("RATIO"), "Invalid RATIO");
+    params.logPriceOffset = uint24(vm.envUint("LOG_PRICE_OFFSET"));
+    require(params.logPriceOffset == vm.envUint("LOG_PRICE_OFFSET"), "Invalid LOG_PRICE_OFFSET");
     params.pricePoints = uint8(vm.envUint("PRICE_POINTS"));
     require(params.pricePoints == vm.envUint("PRICE_POINTS"), "Invalid PRICE_POINTS");
     params.spread = uint8(vm.envUint("SPREAD"));
@@ -177,9 +177,8 @@ contract KandelPopulate is Deployer {
   }
 
   function calculateBaseQuote(HeapArgs memory args) public view returns (CoreKandel.Distribution memory distribution) {
-    (distribution, /* uint lastQuote */ ) = KandelLib.calculateDistribution(
-      args.from, args.to, args.volume, args.initQuote, args.params.ratio, args.kdl.PRECISION()
-    );
+    (distribution, /* uint lastQuote */ ) =
+      KandelLib.calculateDistribution(args.from, args.to, args.volume, args.initQuote, args.params.logPriceOffset);
   }
 
   ///@notice evaluates required amounts that need to be published on Mangrove

--- a/script/strategies/kandel/deployers/KandelDeployer.s.sol
+++ b/script/strategies/kandel/deployers/KandelDeployer.s.sol
@@ -51,7 +51,6 @@ contract KandelDeployer is Deployer {
       broadcaster()
     );
 
-    uint precision = current.PRECISION();
     broadcast();
 
     string memory kandelName = new KandelSower().getName(name, olKeyBaseQuote, false);

--- a/src/strategies/offer_maker/market_making/kandel/abstract/GeometricKandel.sol
+++ b/src/strategies/offer_maker/market_making/kandel/abstract/GeometricKandel.sol
@@ -8,28 +8,25 @@ import {OfferType} from "./TradesBaseQuotePair.sol";
 import {CoreKandel} from "./CoreKandel.sol";
 import {AbstractKandel} from "./AbstractKandel.sol";
 import {LogPriceConversionLib} from "mgv_lib/LogPriceConversionLib.sol";
+import {MAX_LOG_PRICE, MIN_LOG_PRICE} from "mgv_lib/Constants.sol";
 
 ///@title Adds a geometric price progression to a `CoreKandel` strat without storing prices for individual price points.
 abstract contract GeometricKandel is CoreKandel {
-  ///@notice GeometricKandel's `ratio` has PRECISION decimals
-  ///@notice setting PRECISION higher than 5 will produce overflow in limit cases for GeometricKandel.
-  uint public constant PRECISION = 5;
-
   ///@notice the parameters for Geometric Kandel have been set.
   ///@param spread in amount of price slots to jump for posting dual offer
-  ///@param ratio of price progression
-  event SetGeometricParams(uint spread, uint ratio);
+  ///@param logPriceOffset of price progression
+  event SetGeometricParams(uint spread, uint logPriceOffset);
 
   ///@notice Geometric Kandel parameters
   ///@param gasprice the gasprice to use for offers
   ///@param gasreq the gasreq to use for offers
-  ///@param ratio of price progression (`2**16 > ratio >= 10**PRECISION`) expressed with `PRECISION` decimals, so geometric ratio is `ratio/10**PRECISION`
+  ///@param logPriceOffset the offset between logPrice for two consecutive price points.
   ///@param spread in amount of price slots to jump for posting dual offer. Must be less than or equal to 8.
   ///@param pricePoints the number of price points for the Kandel instance.
   struct Params {
     uint16 gasprice;
     uint24 gasreq;
-    uint24 ratio; // max ratio is 2*10**5
+    uint24 logPriceOffset;
     uint8 spread;
     uint8 pricePoints;
   }
@@ -76,9 +73,10 @@ abstract contract GeometricKandel is CoreKandel {
     }
 
     bool geometricChanged = false;
-    if (oldParams.ratio != newParams.ratio) {
-      require(newParams.ratio >= 10 ** PRECISION && newParams.ratio <= 2 * 10 ** PRECISION, "Kandel/invalidRatio");
-      params.ratio = newParams.ratio;
+
+    if (oldParams.logPriceOffset != newParams.logPriceOffset) {
+      require(int(uint(newParams.logPriceOffset)) <= MAX_LOG_PRICE - MIN_LOG_PRICE, "Kandel/invalidLogPriceOffset");
+      params.logPriceOffset = newParams.logPriceOffset;
       geometricChanged = true;
     }
     if (oldParams.spread != newParams.spread) {
@@ -88,7 +86,7 @@ abstract contract GeometricKandel is CoreKandel {
     }
 
     if (geometricChanged) {
-      emit SetGeometricParams(newParams.spread, newParams.ratio);
+      emit SetGeometricParams(newParams.spread, newParams.logPriceOffset);
     }
 
     if (newParams.gasprice != 0 && newParams.gasprice != oldParams.gasprice) {
@@ -108,7 +106,7 @@ abstract contract GeometricKandel is CoreKandel {
   ///@param quoteAmount quote amount to deposit
   ///@dev This function is used at initialization and can fund with provision for the offers.
   ///@dev Use `populateChunk` to split up initialization or re-initialization with same parameters, as this function will emit.
-  ///@dev If this function is invoked with different ratio, pricePoints, spread, then first retract all offers.
+  ///@dev If this function is invoked with different logPriceOffset, pricePoints, spread, then first retract all offers.
   ///@dev msg.value must be enough to provision all posted offers (for chunked initialization only one call needs to send native tokens).
   function populate(
     Distribution calldata distribution,
@@ -149,10 +147,11 @@ abstract contract GeometricKandel is CoreKandel {
   ///@param dualOfferGives the dual offer's current gives (can be 0)
   ///@param order a recap of the taker order (order.offer is the executed offer)
   ///@param memoryParams the Kandel params (possibly with modified spread due to boundary condition)
-  ///@return wants the new wants for the dual offer
+  ///@return logPrice the log price for the dual offer
   ///@return gives the new gives for the dual offer
-  ///@dev Define the (maker) price of the order as `p_order := order.offer.wants() / order.offer.gives()` (what the offer originally wants by what the offer originally gives).
-  /// the (maker) price of the dual order must be `p_dual := p_order / ratio^spread` at which one should buy back at least what was sold.
+  ///@dev Define the (maker) price of the order as `p_order` with the log price of the order being `l_order := order.offer.logPrice()`
+  /// the (maker) price of the dual order must be `p_dual := p_order / ratio^spread` which with the `logPriceOffset` defining the ratio means the log price of the dual
+  /// becomes `l_dual := -(l_order - logPriceOffset*spread)` at which one should buy back at least what was sold.
   /// Now, since we do maximal compounding, maker wants to give all what taker gave. That is `max_offer_gives := order.gives`
   /// which we use in the code below where we also account for existing gives of the dual offer.
   function dualWantsGivesOfOffer(
@@ -160,14 +159,8 @@ abstract contract GeometricKandel is CoreKandel {
     uint dualOfferGives,
     MgvLib.SingleOrder calldata order,
     Params memory memoryParams
-  ) internal pure returns (uint wants, uint gives) {
-    // computing gives/wants for dual offer
-    // we verify we cannot overflow if PRECISION = 5
-    // spread:8
+  ) internal pure returns (int logPrice, uint gives) {
     uint spread = uint(memoryParams.spread);
-    // params.ratio <= 2*10**PRECISION, spread:8, r: 8 * (PRECISION*log2(10) + 1)
-    uint r = uint(memoryParams.ratio) ** spread;
-    uint p = 10 ** PRECISION;
     // order.gives:96
     gives = order.gives;
 
@@ -176,31 +169,11 @@ abstract contract GeometricKandel is CoreKandel {
     gives += dualOfferGives;
     if (uint96(gives) != gives) {
       // this should not be reached under normal circumstances unless strat is posting on top of an existing offer with an abnormal volume
-      // to prevent gives to be too high, we let the surplus be pending
+      // to prevent gives to be too high, we let the surplus become "pending" (unpublished liquidity)
       gives = type(uint96).max;
     }
-    // adjusting wants to price:
-    // gives * r : 237 so offerGives must be < 2**19 to completely avoid overflow.
-    // Since offerGives is high when gives * r is, we check whether the full precision can be used and only if not then we use less precision.
-    uint givesR = gives * r;
-    uint offerGives = order.offer.gives();
-    if (uint160(givesR) == givesR || offerGives < 2 ** 19) {
-      // using max precision
-      wants = (offerGives * givesR) / (order.offer.wants() * (p ** spread));
-    } else {
-      // we divide `gives*r` by `order.offer.wants()` with max precision so that the resulting `givesR:160` in order to make sure it can be multiplied by `offerGives`
-      givesR = (givesR * 2 ** 19) / order.offer.wants();
-      wants = (offerGives * givesR) / (p ** spread);
-      // we correct for the added precision above
-      wants /= 2 ** 19;
-    }
-    // wants is higher than offerGives
-    // this may cause wants to be higher than 2**96 allowed by Mangrove (for instance if one needs many quotes to buy sell base tokens)
-    // so we adjust the price so as to want an amount of tokens that mangrove will accept.
-    if (uint96(wants) != wants) {
-      gives = (type(uint96).max * gives) / wants;
-      wants = type(uint96).max;
-    }
+    //FIXME: can wants be too high or too low?
+    logPrice = -(order.offer.logPrice() - int(uint(memoryParams.logPriceOffset)) * int(spread));
   }
 
   ///@notice returns the destination index to transport received liquidity to - a better (for Kandel) price index for the offer type.
@@ -254,17 +227,7 @@ abstract contract GeometricKandel is CoreKandel {
     args.olKey = offerListOfOfferType(baDual);
     MgvStructs.OfferPacked dualOffer = MGV.offers(args.olKey, dualOfferId);
 
-    // computing gives/wants for dual offer
-    // At least: gives = order.gives/ratio and wants is then order.wants
-    // At most: gives = order.gives and wants is adapted to match the price
-    uint wants;
-    (wants, args.gives) = dualWantsGivesOfOffer(baDual, dualOffer.gives(), order, memoryParams);
-    if (wants > 0) {
-      // FIXME: logPrice should only be updated on new offer or due to price updates, so would be better to set it outside
-      args.logPrice = LogPriceConversionLib.logPriceFromVolumes(wants, args.gives);
-    } else {
-      args.gives = 0;
-    }
+    (args.logPrice, args.gives) = dualWantsGivesOfOffer(baDual, dualOffer.gives(), order, memoryParams);
 
     // args.fund = 0; the offers are already provisioned
     // posthook should not fail if unable to post offers, we capture the error as incidents

--- a/test/strategies/kandel/AaveKandel.t.sol
+++ b/test/strategies/kandel/AaveKandel.t.sol
@@ -331,7 +331,7 @@ contract AaveKandelTest is CoreKandelTest {
 
   function test_liquidity_borrow_marketOrder_attack() public {
     /// adding as many offers as possible (adding more will stack overflow when failing offer will cascade)
-    deployOtherKandel(0.1 ether, 100 * 10 ** 6, uint24(1001 * 10 ** PRECISION / 1000), 1, 137);
+    deployOtherKandel(0.1 ether, 100 * 10 ** 6, 100, 1, 137);
     //printOrderBook($(quote), $(base));
     // base is weth and has a borrow cap, so trying the attack on quote
     address dai = fork.get("DAI");

--- a/test/strategies/kandel/abstract/CoreKandel.t.sol
+++ b/test/strategies/kandel/abstract/CoreKandel.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.10;
 
 import "./KandelTest.t.sol";
+import {MAX_LOG_PRICE, MIN_LOG_PRICE} from "mgv_lib/Constants.sol";
 
 abstract contract CoreKandelTest is KandelTest {
   function setUp() public virtual override {
@@ -524,13 +525,13 @@ abstract contract CoreKandelTest is KandelTest {
   }
 
   function test_transport_below_min_price_accumulates_at_index_0() public {
-    uint24 ratio = uint24(108 * 10 ** PRECISION / 100);
+    uint24 logPriceOffset = 769; // corresponding to roughly to 107.992%
 
     (CoreKandel.Distribution memory distribution1, uint lastQuote) =
-      KandelLib.calculateDistribution(0, 5, initBase, initQuote, ratio, PRECISION);
+      KandelLib.calculateDistribution(0, 5, initBase, initQuote, logPriceOffset);
 
     (CoreKandel.Distribution memory distribution2,) =
-      KandelLib.calculateDistribution(5, 10, initBase, lastQuote, ratio, PRECISION);
+      KandelLib.calculateDistribution(5, 10, initBase, lastQuote, logPriceOffset);
 
     // setting params.spread to 2
     GeometricKandel.Params memory params = getParams(kdl);
@@ -684,13 +685,13 @@ abstract contract CoreKandelTest is KandelTest {
 
     GeometricKandel.Params memory paramsNew;
     paramsNew.pricePoints = params.pricePoints;
-    paramsNew.ratio = params.ratio + 1;
+    paramsNew.logPriceOffset = params.logPriceOffset + 1;
     paramsNew.spread = params.spread + 1;
     paramsNew.gasprice = params.gasprice + 1;
     paramsNew.gasreq = params.gasreq + 1;
 
     expectFrom(address(kdl));
-    emit SetGeometricParams(paramsNew.spread, paramsNew.ratio);
+    emit SetGeometricParams(paramsNew.spread, paramsNew.logPriceOffset);
     expectFrom(address(kdl));
     emit SetGasprice(paramsNew.gasprice);
     expectFrom(address(kdl));
@@ -704,28 +705,17 @@ abstract contract CoreKandelTest is KandelTest {
     assertEq(params_.gasprice, paramsNew.gasprice, "gasprice should be changed");
     assertEq(params_.gasreq, paramsNew.gasreq, "gasreq should be changed");
     assertEq(params_.pricePoints, params.pricePoints, "pricePoints should not be changed");
-    assertEq(params_.ratio, paramsNew.ratio, "ratio should be changed");
+    assertEq(params_.logPriceOffset, paramsNew.logPriceOffset, "logPriceOffset should be changed");
     assertEq(params_.spread, params.spread + 1, "spread should be changed");
     assertEq(offeredVolumeBase, kdl.offeredVolume(Ask), "ask volume should be unchanged");
     assertEq(offeredVolumeQuote, kdl.offeredVolume(Bid), "ask volume should be unchanged");
     assertStatus(dynamic([uint(1), 1, 1, 1, 1, 2, 2, 2, 2, 2]), type(uint).max, type(uint).max);
   }
 
-  function test_populate_throws_on_invalid_ratio() public {
-    uint precision = PRECISION;
-    GeometricKandel.Params memory params;
-    params.pricePoints = 10;
-    params.ratio = uint24(10 ** precision - 1);
-    params.spread = 1;
-    vm.prank(maker);
-    vm.expectRevert("Kandel/invalidRatio");
-    kdl.populate(emptyDist, 0, params, 0, 0);
-  }
-
   function test_populate_throws_on_invalid_spread_low() public {
     GeometricKandel.Params memory params;
     params.pricePoints = 10;
-    params.ratio = uint24(10 ** PRECISION);
+    params.logPriceOffset = 769;
     params.spread = 0;
     vm.prank(maker);
     vm.expectRevert("Kandel/invalidSpread");
@@ -735,7 +725,7 @@ abstract contract CoreKandelTest is KandelTest {
   function test_populate_throws_on_invalid_spread_high() public {
     GeometricKandel.Params memory params;
     params.pricePoints = 10;
-    params.ratio = uint24(10 ** PRECISION);
+    params.logPriceOffset = 769;
     params.spread = 9;
     vm.prank(maker);
     vm.expectRevert("Kandel/invalidSpread");
@@ -750,13 +740,13 @@ abstract contract CoreKandelTest is KandelTest {
     vm.prank(maker);
     kdl.retractOffers(0, 10);
 
-    uint24 ratio = uint24(102 * 10 ** PRECISION / 100);
+    uint24 logPriceOffset = 200;
     (CoreKandel.Distribution memory distribution,) =
-      KandelLib.calculateDistribution(0, 5, initBase, initQuote, ratio, PRECISION);
+      KandelLib.calculateDistribution(0, 5, initBase, initQuote, logPriceOffset);
 
     GeometricKandel.Params memory params;
     params.pricePoints = 5;
-    params.ratio = ratio;
+    params.logPriceOffset = logPriceOffset;
     params.spread = 2;
 
     expectFrom(address(kdl));
@@ -930,7 +920,7 @@ abstract contract CoreKandelTest is KandelTest {
     //assertTrue(makerExecuteCost + posthookCost <= kdl.offerGasreq() + local.offer_gasbase(), "Strat is spending more gas");
   }
 
-  function deployOtherKandel(uint base0, uint quote0, uint24 ratio, uint8 spread, uint8 pricePoints) internal {
+  function deployOtherKandel(uint base0, uint quote0, uint24 logPriceOffset, uint8 spread, uint8 pricePoints) internal {
     address otherMaker = freshAddress();
 
     GeometricKandel otherKandel = __deployKandel__(otherMaker, otherMaker);
@@ -948,11 +938,11 @@ abstract contract CoreKandelTest is KandelTest {
     deal(otherMaker, totalProvision);
 
     (CoreKandel.Distribution memory distribution,) =
-      KandelLib.calculateDistribution(0, pricePoints, base0, quote0, ratio, otherKandel.PRECISION());
+      KandelLib.calculateDistribution(0, pricePoints, base0, quote0, logPriceOffset);
 
     GeometricKandel.Params memory params;
     params.pricePoints = pricePoints;
-    params.ratio = ratio;
+    params.logPriceOffset = logPriceOffset;
     params.spread = spread;
     vm.prank(otherMaker);
     otherKandel.populate{value: totalProvision}(distribution, pricePoints / 2, params, 0, 0);
@@ -985,8 +975,6 @@ abstract contract CoreKandelTest is KandelTest {
     uint8 spread = 8;
     uint8 pricePoints = type(uint8).max;
 
-    uint precision = PRECISION;
-
     vm.prank(maker);
     kdl.retractOffers(0, 10);
 
@@ -998,7 +986,7 @@ abstract contract CoreKandelTest is KandelTest {
         quote: type(uint96).max,
         firstAskIndex: 2,
         pricePoints: pricePoints,
-        ratio: 2 * 10 ** precision,
+        logPriceOffset: 2 ** 24,
         spread: spread,
         expectRevert: bytes("")
       });
@@ -1037,10 +1025,9 @@ abstract contract CoreKandelTest is KandelTest {
   }
 
   function test_dualWantsGivesOfOffer_nearBoundary_correctPrice(OfferType ba) internal {
+    //FIXME what should we do near boundaries? Should dual posting just fail?
     uint8 spread = 3;
     uint8 pricePoints = 6;
-
-    uint precision = PRECISION;
 
     vm.prank(maker);
     kdl.retractOffers(0, 10);
@@ -1052,7 +1039,7 @@ abstract contract CoreKandelTest is KandelTest {
       quote: initQuote,
       firstAskIndex: ba == Bid ? pricePoints : 0,
       pricePoints: pricePoints,
-      ratio: 2 * 10 ** precision,
+      logPriceOffset: uint(MAX_LOG_PRICE - MIN_LOG_PRICE),
       spread: spread,
       expectRevert: bytes("")
     });
@@ -1062,11 +1049,11 @@ abstract contract CoreKandelTest is KandelTest {
     if (ba == Bid) {
       MgvStructs.OfferPacked ask = kdl.getOffer(Ask, 5);
       assertApproxEqRel(ask.gives(), initBase, 1e14, "wrong gives");
-      assertApproxEqRel(ask.wants(), ask.gives() * 2 / 1000000000, 1e14, "wrong price");
+      assertApproxEqRel(ask.logPrice(), 42, 1e14, "wrong price");
     } else {
       MgvStructs.OfferPacked bid = kdl.getOffer(Bid, 0);
       assertApproxEqRel(bid.gives(), initQuote, 1e14, "wrong gives");
-      assertApproxEqRel(bid.wants(), bid.gives() * 2 * 1000000000, 1e14, "wrong price");
+      assertApproxEqRel(bid.logPrice(), 42, 1e14, "wrong price");
     }
   }
 
@@ -1088,7 +1075,6 @@ abstract contract CoreKandelTest is KandelTest {
     kdl.MGV();
     kdl.NO_ROUTER();
     kdl.OFFER_GASREQ();
-    kdl.PRECISION();
     kdl.QUOTE();
     kdl.RESERVE_ID();
     kdl.TICK_SCALE();

--- a/test/strategies/kandel/abstract/KandelTest.t.sol
+++ b/test/strategies/kandel/abstract/KandelTest.t.sol
@@ -30,12 +30,11 @@ abstract contract KandelTest is StratTest {
 
   OfferType constant Ask = OfferType.Ask;
   OfferType constant Bid = OfferType.Bid;
-  uint PRECISION;
 
   event Mgv(IMangrove mgv);
   event OfferListKey(IERC20 base, IERC20 quote, uint tickScale);
   event NewKandel(address indexed owner, bytes32 indexed olKeyHash, address kandel);
-  event SetGeometricParams(uint spread, uint ratio);
+  event SetGeometricParams(uint spread, uint logPriceOffset);
   event SetLength(uint value);
   event SetGasreq(uint value);
   event Credit(IERC20 indexed token, uint amount);
@@ -95,7 +94,6 @@ abstract contract KandelTest is StratTest {
     bufferedGasprice = globalGasprice * 10; // covering 10 times Mangrove's gasprice at deploy time
 
     kdl = __deployKandel__(maker, maker);
-    PRECISION = kdl.PRECISION();
 
     // funding Kandel on Mangrove
     uint provAsk = reader.getProvision(olKey, kdl.offerGasreq(), bufferedGasprice);
@@ -108,16 +106,20 @@ abstract contract KandelTest is StratTest {
     vm.prank(maker);
     TransferLib.approveToken(quote, address(kdl), type(uint).max);
 
-    uint ratio = 108 * 10 ** (PRECISION - 2);
+    // A ratio of ~108% can be converted to a log price step of ~769 via
+    //int logPriceOffset = LogPriceConversionLib.logPriceFromVolumes(1 ether * uint(108000) / (100000), 1 ether);
+    uint logPriceOffset = 769;
+    // and vice versa with
+    // ratio = uint24(LogPriceLib.inboundFromOutbound(logPriceOffset, 1 ether) * 100000 / LogPriceLib.inboundFromOutbound(0, 1 ether)
 
     (CoreKandel.Distribution memory distribution1, uint lastQuote) =
-      KandelLib.calculateDistribution(0, 5, initBase, initQuote, ratio, PRECISION);
+      KandelLib.calculateDistribution(0, 5, initBase, initQuote, logPriceOffset);
 
     (CoreKandel.Distribution memory distribution2,) =
-      KandelLib.calculateDistribution(5, 10, initBase, lastQuote, ratio, PRECISION);
+      KandelLib.calculateDistribution(5, 10, initBase, lastQuote, logPriceOffset);
 
     GeometricKandel.Params memory params;
-    params.ratio = uint24(ratio);
+    params.logPriceOffset = uint24(logPriceOffset);
     params.spread = STEP;
     params.pricePoints = 10;
     vm.prank(maker);
@@ -170,11 +172,11 @@ abstract contract KandelTest is StratTest {
   }
 
   function getParams(GeometricKandel aKandel) internal view returns (GeometricKandel.Params memory params) {
-    (uint16 gasprice, uint24 gasreq, uint24 ratio, uint8 spread, uint8 pricePoints) = aKandel.params();
+    (uint16 gasprice, uint24 gasreq, uint24 logPriceOffset, uint8 spread, uint8 pricePoints) = aKandel.params();
 
     params.gasprice = gasprice;
     params.gasreq = gasreq;
-    params.ratio = ratio;
+    params.logPriceOffset = logPriceOffset;
     params.spread = spread;
     params.pricePoints = pricePoints;
   }
@@ -266,7 +268,7 @@ abstract contract KandelTest is StratTest {
       OfferStatus offerStatus = OfferStatus(offerStatuses[i]);
       assertStatus(i, offerStatus, q, b);
       if (q != type(uint).max) {
-        q = (q * uint(params.ratio)) / (10 ** PRECISION);
+        q = (q * LogPriceLib.inboundFromOutbound(int(uint(params.logPriceOffset)), 1 ether)) / 1 ether;
       }
       if (offerStatus == OfferStatus.Ask) {
         expectedAsks++;
@@ -319,7 +321,7 @@ abstract contract KandelTest is StratTest {
   ) internal {
     GeometricKandel.Params memory params = getParams(kdl);
     populateSingle(
-      kandel, index, base, quote, firstAskIndex, params.pricePoints, params.ratio, params.spread, expectRevert
+      kandel, index, base, quote, firstAskIndex, params.pricePoints, params.logPriceOffset, params.spread, expectRevert
     );
   }
 
@@ -330,7 +332,7 @@ abstract contract KandelTest is StratTest {
     uint quote,
     uint firstAskIndex,
     uint pricePoints,
-    uint ratio,
+    uint logPriceOffset,
     uint spread,
     bytes memory expectRevert
   ) internal {
@@ -348,7 +350,7 @@ abstract contract KandelTest is StratTest {
     }
     GeometricKandel.Params memory params;
     params.pricePoints = uint8(pricePoints);
-    params.ratio = uint24(ratio);
+    params.logPriceOffset = uint24(logPriceOffset);
     params.spread = uint8(spread);
 
     kandel.populate{value: 0.1 ether}(distribution, firstAskIndex, params, 0, 0);
@@ -416,7 +418,7 @@ abstract contract KandelTest is StratTest {
         numDead++;
       }
       quoteAtIndex[i] = quote;
-      quote = (quote * uint(params.ratio)) / 10 ** PRECISION;
+      quote = (quote * LogPriceLib.inboundFromOutbound(int(uint(params.logPriceOffset)), 1 ether)) / 1 ether;
     }
 
     // truncate indices - cannot do push to memory array


### PR DESCRIPTION
Use logPriceOffset instead of ratio. Increases price interval Kandel can operate on, and spends less gas doing calculations, and price calculations are now precise.