### PR TITLE
feat(MangroveOrder): Allow re-use of dead, owned offers to save gas and provision

### DIFF
--- a/src/strategies/MangroveOrder.sol
+++ b/src/strategies/MangroveOrder.sol
@@ -281,6 +281,8 @@ contract MangroveOrder is Forwarder, IOrderLogic {
       require(!MGV.offers(olKey, offerId).isLive(), "mgvOrder/offerAlreadyActive");
       if (_updateOffer(args, offerId) == REPOST_SUCCESS) {
         res.offerId = offerId;
+      } else {
+        res.offerId = 0;
       }
     }
     if (res.offerId == 0) {

--- a/src/strategies/interfaces/IOrderLogic.sol
+++ b/src/strategies/interfaces/IOrderLogic.sol
@@ -22,6 +22,7 @@ interface IOrderLogic {
     bool fillWants;
     bool restingOrder;
     uint expiryDate;
+    uint offerId;
   }
 
   ///@notice Result of an order from the takers side.

--- a/src/strategies/interfaces/IOrderLogic.sol
+++ b/src/strategies/interfaces/IOrderLogic.sol
@@ -14,6 +14,7 @@ interface IOrderLogic {
   ///@param fillWants if true (buying), the market order stops when `fillVolume` units of `olKey.outbound` have been obtained (fee included); otherwise (selling), the market order stops when `fillVolume` units of `olKey.inbound` have been sold.
   ///@param restingOrder whether the complement of the partial fill (if any) should be posted as a resting limit order.
   ///@param expiryDate timestamp (expressed in seconds since unix epoch) beyond which the order is no longer valid, 0 means forever
+  ///@param offerId the id of an existing, dead offer owned by the taker to re-use for the resting order, 0 means no re-use.
   struct TakerOrder {
     OLKey olKey;
     bool fillOrKill;

--- a/test/strategies/MgvOrder.t.sol
+++ b/test/strategies/MgvOrder.t.sol
@@ -203,7 +203,8 @@ contract MangroveOrder_Test is StratTest {
       fillVolume: fillVolume,
       logPrice: logPriceFromPrice_e18(MID_PRICE - 1e18),
       restingOrder: false,
-      expiryDate: 0 //NA
+      expiryDate: 0, //NA
+      offerId: 0
     });
   }
 
@@ -246,7 +247,8 @@ contract MangroveOrder_Test is StratTest {
       logPrice: -logPriceFromPrice_e18(MID_PRICE - 9e18),
       fillVolume: fillVolume,
       restingOrder: false,
-      expiryDate: 0 //NA
+      expiryDate: 0, //NA
+      offerId: 0
     });
   }
 


### PR DESCRIPTION
TODO: add tests of reuse and verify guards.