### PR TITLE
feat: up mangrove-core

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -96,9 +96,9 @@ __metadata:
   linkType: hard
 
 "@mangrovedao/mangrove-core@npm:next":
-  version: 1.5.11-2
-  resolution: "@mangrovedao/mangrove-core@npm:1.5.11-2"
-  checksum: 3b5cea4b6663e60be9936d104f228fa7282efa2cefacf72361b918423c68d0faebf8f30f02aa7a4ae8e7f27b20d93675591fb0dfe08502dab5c35441cbd95172
+  version: 2.0.0-3
+  resolution: "@mangrovedao/mangrove-core@npm:2.0.0-3"
+  checksum: 7072e48bd78e9e784d4b07d50eb86ae459e63a884c3999ed6d5c0567c95ab6c00d60ba50800feb117c15641eb207026ca59076f15005c0e2ba44ef20b4bbdacb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
we use "next" version. This updates the yarn.lock file to the newest next version