### PR TITLE
fix: add flipped olKeyHash to newKandel events

### DIFF
--- a/src/strategies/offer_maker/market_making/kandel/AaveKandelSeeder.sol
+++ b/src/strategies/offer_maker/market_making/kandel/AaveKandelSeeder.sol
@@ -11,11 +11,18 @@ import {OLKey} from "@mgv/src/core/MgvLib.sol";
 contract AaveKandelSeeder is AbstractKandelSeeder {
   ///@notice a new Kandel with pooled AAVE router has been deployed.
   ///@param owner the owner of the strat. This is indexed so that RPC calls can filter on it.
-  ///@param olKeyHash the hash of the offer list key. This is indexed so that RPC calls can filter on it.
+  ///@param baseQuoteOlKeyHash the hash of the base/quote offer list key. This is indexed so that RPC calls can filter on it.
+  ///@param quoteBaseOlKeyHash the hash of the quote/base offer list key. This is indexed so that RPC calls can filter on it.
   ///@param aaveKandel the address of the deployed strat.
   ///@param reserveId the reserve identifier used for the router.
   ///@notice By emitting this data, an indexer will be able to keep track of what Kandel strats are deployed, what market its deployed on, who the owner is and what reserve they use.
-  event NewAaveKandel(address indexed owner, bytes32 indexed olKeyHash, address aaveKandel, address reserveId);
+  event NewAaveKandel(
+    address indexed owner,
+    bytes32 indexed baseQuoteOlKeyHash,
+    bytes32 indexed quoteBaseOlKeyHash,
+    address aaveKandel,
+    address reserveId
+  );
 
   ///@notice the Aave router.
   AavePooledRouter public immutable AAVE_ROUTER;
@@ -49,6 +56,6 @@ contract AaveKandelSeeder is AbstractKandelSeeder {
     AAVE_ROUTER.bind(address(kandel));
     // Setting AaveRouter as Kandel's router and activating router on BASE and QUOTE ERC20
     AaveKandel(payable(kandel)).initialize(AAVE_ROUTER);
-    emit NewAaveKandel(msg.sender, olKeyBaseQuote.hash(), address(kandel), owner);
+    emit NewAaveKandel(msg.sender, olKeyBaseQuote.hash(), olKeyBaseQuote.flipped().hash(), address(kandel), owner);
   }
 }

--- a/src/strategies/offer_maker/market_making/kandel/KandelSeeder.sol
+++ b/src/strategies/offer_maker/market_making/kandel/KandelSeeder.sol
@@ -11,10 +11,13 @@ import {OLKey} from "@mgv/src/core/MgvLib.sol";
 contract KandelSeeder is AbstractKandelSeeder {
   ///@notice a new Kandel has been deployed.
   ///@param owner the owner of the strat. This is indexed so that RPC calls can filter on it.
-  ///@param olKeyHash the hash of the offer list key. This is indexed so that RPC calls can filter on it.
+  ///@param baseQuoteOlKeyHash the hash of the base/quote offer list key. This is indexed so that RPC calls can filter on it.
+  ///@param quoteBaseOlKeyHash the hash of the quote/base offer list key. This is indexed so that RPC calls can filter on it.
   ///@param kandel the address of the deployed strat.
   ///@notice By emitting this data, an indexer will be able to keep track of what Kandel strats are deployed, what market its deployed on and who the owner is.
-  event NewKandel(address indexed owner, bytes32 indexed olKeyHash, address kandel);
+  event NewKandel(
+    address indexed owner, bytes32 indexed baseQuoteOlKeyHash, bytes32 indexed quoteBaseOlKeyHash, address kandel
+  );
 
   ///@notice constructor for `KandelSeeder`.
   ///@param mgv The Mangrove deployment.
@@ -24,6 +27,6 @@ contract KandelSeeder is AbstractKandelSeeder {
   ///@inheritdoc AbstractKandelSeeder
   function _deployKandel(OLKey memory olKeyBaseQuote, bool) internal override returns (GeometricKandel kandel) {
     kandel = new Kandel(MGV, olKeyBaseQuote, KANDEL_GASREQ, address(0));
-    emit NewKandel(msg.sender, olKeyBaseQuote.hash(), address(kandel));
+    emit NewKandel(msg.sender, olKeyBaseQuote.hash(), olKeyBaseQuote.flipped().hash(), address(kandel));
   }
 }

--- a/test/strategies/kandel/KandelSeeder.t.sol
+++ b/test/strategies/kandel/KandelSeeder.t.sol
@@ -22,8 +22,16 @@ contract KandelSeederTest is StratTest {
   AbstractKandelSeeder internal aaveSeeder;
   AavePooledRouter internal aaveRouter;
 
-  event NewAaveKandel(address indexed owner, bytes32 indexed olKeyHash, address aaveKandel, address reserveId);
-  event NewKandel(address indexed owner, bytes32 indexed olKeyHash, address kandel);
+  event NewAaveKandel(
+    address indexed owner,
+    bytes32 indexed baseQuoteOlKeyHash,
+    bytes32 indexed quoteBaseOlKeyHash,
+    address aaveKandel,
+    address reserveId
+  );
+  event NewKandel(
+    address indexed owner, bytes32 indexed baseQuoteOlKeyHash, bytes32 indexed quoteBaseOlKeyHash, address kandel
+  );
 
   function sow(bool sharing) internal returns (GeometricKandel) {
     return seeder.sow({olKeyBaseQuote: olKey, liquiditySharing: sharing});
@@ -80,7 +88,7 @@ contract KandelSeederTest is StratTest {
   function test_logs_new_aaveKandel() public {
     address maker = freshAddress("Maker");
     expectFrom(address(aaveSeeder));
-    emit NewAaveKandel(maker, olKey.hash(), 0x9f92659F6b974ce0c1C144F57dbE5981bCdFa515, maker);
+    emit NewAaveKandel(maker, olKey.hash(), olKey.flipped().hash(), 0x9f92659F6b974ce0c1C144F57dbE5981bCdFa515, maker);
     vm.prank(maker);
     sowAave(true);
   }
@@ -88,7 +96,7 @@ contract KandelSeederTest is StratTest {
   function test_logs_new_kandel() public {
     address maker = freshAddress("Maker");
     expectFrom(address(seeder));
-    emit NewKandel(maker, olKey.hash(), 0x42add52666C78960A219b157a1F4DbF806CbF703);
+    emit NewKandel(maker, olKey.hash(), olKey.flipped().hash(), 0x42add52666C78960A219b157a1F4DbF806CbF703);
     vm.prank(maker);
     sow(true);
   }

--- a/test/strategies/kandel/abstract/KandelTest.t.sol
+++ b/test/strategies/kandel/abstract/KandelTest.t.sol
@@ -37,7 +37,9 @@ abstract contract KandelTest is StratTest {
 
   event Mgv(IMangrove mgv);
   event OfferListKey(bytes32 olKeyHash);
-  event NewKandel(address indexed owner, bytes32 indexed olKeyHash, address kandel);
+  event NewKandel(
+    address indexed owner, bytes32 indexed baseQuoteOlKeyHash, bytes32 indexed quoteBaseOlKeyHash, address kandel
+  );
   event SetStepSize(uint value);
   event SetLength(uint value);
   event SetGasreq(uint value);


### PR DESCRIPTION
The flipped olKeyHash is needed for indexing kandel. 
In the indexer each market(offerList) is saved with the Id as the olKeyHash. In subgraph, you can only find entities by their id. This is fine for most events, as the emit olKeyHash. But e.g. in kandel we have events like SetIndexMapping, where the assumption is that the indexer already knows what offerLists, that are being used, so the olKeyHash is not emitted. 
But with the current NewKandel events, the indexer only knows the olKeyHash of the base/quote offerlist and not the quote/base offerlist. 
This PR updates the NewKandel events, so that it emits both olKeyHash's.