### PR TITLE
fix: Fix natspec issues that broke solidity-docgen for Hardhat

### DIFF
--- a/src/strategies/offer_forwarder/abstract/Forwarder.sol
+++ b/src/strategies/offer_forwarder/abstract/Forwarder.sol
@@ -162,8 +162,6 @@ abstract contract Forwarder is IForwarder, MangroveOffer {
     }
   }
 
-  ///@notice Internal `updateOffer`, using arguments and variables on memory to avoid stack too deep.
-  ///@return reason is either REPOST_SUCCESS or Mangrove's revert reason if update was rejected by Mangrove and `args.noRevert` is `true`.
   struct UpdateOfferVars {
     uint leftover;
     Global global;
@@ -172,7 +170,9 @@ abstract contract Forwarder is IForwarder, MangroveOffer {
   }
 
   ///@inheritdoc MangroveOffer
-  function _updateOffer(OfferArgs memory args, uint offerId) internal override returns (bytes32) {
+  ///@notice Internal `updateOffer`, using arguments and variables on memory to avoid stack too deep.
+  ///@return reason Either REPOST_SUCCESS or Mangrove's revert reason if update was rejected by Mangrove and `args.noRevert` is `true`.
+  function _updateOffer(OfferArgs memory args, uint offerId) internal override returns (bytes32 reason) {
     unchecked {
       UpdateOfferVars memory vars;
       (vars.global, vars.local) = MGV.config(args.olKey);
@@ -205,9 +205,9 @@ abstract contract Forwarder is IForwarder, MangroveOffer {
         args.olKey, args.tick, args.gives, args.gasreq, args.gasprice, offerId
       ) {
         return REPOST_SUCCESS;
-      } catch Error(string memory reason) {
-        require(args.noRevert, reason);
-        return bytes32(bytes(reason));
+      } catch Error(string memory _reason) {
+        require(args.noRevert, _reason);
+        return bytes32(bytes(_reason));
       }
     }
   }

--- a/src/toy_strategies/offer_forwarder/AmplifierForwarder.sol
+++ b/src/toy_strategies/offer_forwarder/AmplifierForwarder.sol
@@ -51,9 +51,6 @@ contract AmplifierForwarder is Forwarder {
    * @param gives in BASE decimals
    * @param wants1 in STABLE1 decimals
    * @param wants2 in STABLE2 decimals
-   * @return (offerid for STABLE1, offerid for STABLE2)
-   * @dev these offer's provision must be in msg.value
-   * @dev `reserve()` must have approved base for `this` contract transfer prior to calling this function
    */
   struct NewOffersArgs {
     uint gives;
@@ -64,6 +61,12 @@ contract AmplifierForwarder is Forwarder {
     uint gasreq;
   }
 
+  /**
+   * @param args the arguments struct to avoid stack too deep
+   * @return (offerid for STABLE1, offerid for STABLE2)
+   * @dev these offer's provision must be in msg.value
+   * @dev `reserve()` must have approved base for `this` contract transfer prior to calling this function
+   */
   function newAmplifiedOffers(NewOffersArgs memory args) external payable returns (uint, uint) {
     // there is a cost of being paternalistic here, we read MGV storage
     // an offer can be in 4 states:


### PR DESCRIPTION
forge doc didn't break but on these issue but did generate nonsense.

NB: The mix of @inheritdoc and other tags works well in forge doc, but not in solidity-docgen: The latter ignores the other tags and only uses the inherited docs.