### PR TITLE
Utra optimized router proxy

### DIFF
--- a/src/strategies/routers/RouterProxyFactory.sol
+++ b/src/strategies/routers/RouterProxyFactory.sol
@@ -71,4 +71,71 @@ contract RouterProxyFactory {
       created = true;
     }
   }
+
+  /**
+   * The custom bytecode for the proxy will be as follows:
+   *
+   * init code (or constructor) of the proxy
+   * // store the caller address to slot 0
+   * [00] CALLER
+   * [01] RETURNDATASIZE // pushes a 0 to the stack
+   * [02] SSTORE
+   *
+   * [03] RETURNDATASIZE // pushes a 0 to the stack
+   * [04-05] PUSH1 2d size of contract code (in bytes, without init code)
+   * [06] DUP1
+   *
+   * [07-08] PUSH1 0d // start line of contract code (in bytes)
+   * [09] RETURNDATASIZE // pushes a 0 to the stack
+   *
+   * [0a] CODECOPY // copies the code with size from [06], from offset [08] to destination offset [0a] (i.e. 0)
+   * [0b] DUP2 // copies the 0 from stack to top
+   * [0c] RETURN // with args: size from [05] and offset as 0 from [09]
+   *
+   * // contract code
+   * // copy the transaction calldata to memory
+   * [0d] CALLDATASIZE // pushes the size of the calldata to the stack
+   * [0e] RETURNDATASIZE // pushes a 0 to the stack
+   * [0f] RETURNDATASIZE // pushes a 0 to the stack
+   * [10] CALLDATACOPY // copies the calldata to memory with size from [0d] and offset 0 and destination offset from 0
+   * // Thus copying the calldata to slot 0 in memory
+   *
+   * // preparing for delegatecall
+   * [11] RETURNDATASIZE // pushes a 0 to the stack (utils that will be used later)
+   * [12] RETURNDATASIZE // 0 for return size to copy
+   * [13] RETURNDATASIZE // 0 for return offset
+   * [14] CALLDATASIZE // pushes the size of the calldata to the stack
+   * [15] RETURNDATASIZE // 0 for args offset
+   * [16-2a] PUSH20 address of router implementation (1 byte for PUSH20 and 20 bytes for address from 18 to 2b)
+   * [2b] GAS // pushes the gas remaining to the stack
+   *
+   * // delegatecall
+   * [2c] DELEGATECALL // calls the router implementation with the calldata from slot 0 in memory
+   * // pushes 01 or 00 to the stack depending on success or failure
+   *
+   * // copy return data to memory
+   * [2d] RETURNDATASIZE // return data size to the stack
+   * [2e] DUP3 // copies the 0 from before [11] to the stack
+   * [2f] DUP1 // copies the 0 from [2e] to the stack
+   * [30] RETURNDATACOPY // copies from offset 0 to destination offset 0 with size from [2f]
+   *
+   * // prepare conditional jump for revert or return
+   * [31] SWAP1 // swaps a 0 for delegatecall success result
+   *            // now stack has delegatecall success result at the bottom and 00 on top
+   * [32] RETURNDATASIZE // pushes the return data size to the stack
+   * [33] SWAP2 // swaps the return data size with the delegatecall success result
+   *            // now stack has return data size at the bottom, 00 above, and delegatecall success result on top
+   * [34-35] PUSH1 43 // counter to jump to (in bytes from start of contract code)
+   * [36] JUMPI // jumps to counter at [35] if delegatecall success result is 01 else continues
+   * [37] REVERT // reverts with return data from slot 0 in memory with size from [32]
+   * [38] JUMPDEST // jump destination for [35]
+   * [39] RETURN // returns with return data from slot 0 in memory with size from [32]
+   *
+   *
+   * @param routerImplementation implementation of the router
+   * @return code of the router implementation
+   */
+  // function getBytecodeFor(address routerImplementation) public pure returns (bytes memory code) {
+
+  // }
 }

--- a/test/strategies/MgvOrder.t.sol
+++ b/test/strategies/MgvOrder.t.sol
@@ -67,6 +67,8 @@ contract MgvOrder_Test is StratTest {
   IOrderLogic.TakerOrderResult internal cold_buyResult;
   IOrderLogic.TakerOrderResult internal cold_sellResult;
 
+  RouterProxyFactory internal factory;
+
   SimpleAaveLogic internal aaveLogic;
 
   receive() external payable {}
@@ -108,7 +110,7 @@ contract MgvOrder_Test is StratTest {
     lo = olKey.flipped();
     setupMarket(olKey);
 
-    RouterProxyFactory factory = new RouterProxyFactory();
+    factory = new RouterProxyFactory();
 
     // this contract is admin of MgvOrder and its router
     mgo = new MgvOrder(IMangrove(payable(mgv)), factory, $(this));
@@ -305,6 +307,13 @@ contract MgvOrder_Test is StratTest {
     order = createSellOrder();
     order.tick = tickFromPrice_e18(MID_PRICE - 1e18).negate();
     order.fillVolume = fillVolume;
+  }
+
+  function test_gas() public {
+    uint remain = gasleft();
+    factory.deployProxy(address(this), AbstractRouter(address(0)));
+    uint used = remain - gasleft();
+    console.log("gas used for proxy deployment: %d", used);
   }
 
   function test_partial_filled_buy_order_is_transferred_to_taker() public {


### PR DESCRIPTION
Later if we want to have an ultra optimized proxy factory, we could allow the RouterProxyFactory to use this bytecode instead of deploying from the other contract.

Description of the bytecode is inspired by EIP1167: https://www.rareskills.io/post/eip-1167-minimal-proxy-standard-with-initialization-clone-pattern

We add the set admin to caller at the beginning of the init code (setting storage slot 0 to caller) and do the modification accordingly.

```txt
// store the caller address to slot 0
[00] CALLER
[01] RETURNDATASIZE // pushes a 0 to the stack
[02] SSTORE

[03] RETURNDATASIZE // pushes a 0 to the stack
[04-05] PUSH1 2d size of contract code (in bytes, without init code)
[06] DUP1

[07-08] PUSH1 0d // start line of contract code (in bytes)
[09] RETURNDATASIZE // pushes a 0 to the stack

[0a] CODECOPY // copies the code with size from [06], from offset [08] to destination offset [0a] (i.e. 0)
[0b] DUP2 // copies the 0 from stack to top
[0c] RETURN // with args: size from [05] and offset as 0 from [09]

// contract code
// copy the transaction calldata to memory
[0d] CALLDATASIZE // pushes the size of the calldata to the stack
[0e] RETURNDATASIZE // pushes a 0 to the stack
[0f] RETURNDATASIZE // pushes a 0 to the stack
[10] CALLDATACOPY // copies the calldata to memory with size from [0d] and offset 0 and destination offset from 0
// Thus copying the calldata to slot 0 in memory

// preparing for delegatecall
[11] RETURNDATASIZE // pushes a 0 to the stack (utils that will be used later)
[12] RETURNDATASIZE // 0 for return size to copy
[13] RETURNDATASIZE // 0 for return offset
[14] CALLDATASIZE // pushes the size of the calldata to the stack
[15] RETURNDATASIZE // 0 for args offset
[16-2a] PUSH20 address of router implementation (1 byte for PUSH20 and 20 bytes for address from 18 to 2b)
[2b] GAS // pushes the gas remaining to the stack

// delegatecall
[2c] DELEGATECALL // calls the router implementation with the calldata from slot 0 in memory
// pushes 01 or 00 to the stack depending on success or failure

// copy return data to memory
[2d] RETURNDATASIZE // return data size to the stack
[2e] DUP3 // copies the 0 from before [11] to the stack
[2f] DUP1 // copies the 0 from [2e] to the stack
[30] RETURNDATACOPY // copies from offset 0 to destination offset 0 with size from [2f]

// prepare conditional jump for revert or return
[31] SWAP1 // swaps a 0 for delegatecall success result
          // now stack has delegatecall success result at the bottom and 00 on top
[32] RETURNDATASIZE // pushes the return data size to the stack
[33] SWAP2 // swaps the return data size with the delegatecall success result
          // now stack has return data size at the bottom, 00 above, and delegatecall success result on top
[34-35] PUSH1 43 // counter to jump to (in bytes from start of contract code)
[36] JUMPI // jumps to counter at [35] if delegatecall success result is 01 else continues
[37] REVERT // reverts with return data from slot 0 in memory with size from [32]
[38] JUMPDEST // jump destination for [35]
[39] RETURN // returns with return data from slot 0 in memory with size from [32]
```