### PR TITLE
build: Set optimizer runs to 200 and add AavePooledRouter to ABI exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Next version
 
 - Add deployer for `SimpleAaveLogic`
+- Add AavePooledRouter to ABI exports
 - Upgrade to @mangrovedao/mangrove-deployments v2.0.1-1
 
 # 2.0.0-b1.2

--- a/config.js
+++ b/config.js
@@ -16,6 +16,7 @@ exports.abi_exports = [
   "AbstractKandelSeeder",
   "KandelSeeder",
   "AaveKandelSeeder",
+  "AavePooledRouter",
   "RouterProxyFactory",
   "SmartRouter",
   "AbstractRoutingLogic",

--- a/foundry.toml
+++ b/foundry.toml
@@ -12,7 +12,7 @@ fs_permissions = [{ access = "read-write", path = "./addresses/"}, { access = "r
 solc_version="0.8.20"
 ffi=true
 optimizer=true
-optimizer_runs=2000
+optimizer_runs=200
 # via_ir=true
 
 # Private keys are expected to be of the form <NETWORK>_PRIVATE_KEY


### PR DESCRIPTION
- Kandel contract becomes too big with more optimizations
- AavePooledRouter is one of the published deployments, so ABI should be exported