### PR TITLE
Response to nethermind audit (#209)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Next version
 
+- Added `outbound_tkn` to `__bundles` mapping key so as to ensure unmanipulated outbound token.
+- Added `freeWei` deprovision on failed `_retractOffer` on forwarder
+- Fixed `freeWei` resetting on each offer retracting while retracting bundle
+- Resetting `cond.volume` on `_updateOffer` instead of `__lastlook__`
+- Using `__residualValues__` to update other offers in the bundle in order to keep a consistent outbound volume
+- logging outbound token at the creation of a new bundle
+- Changing reneging volume condition to a weak inequality
 - feat!: Remove mangrove.js deployer
 - Upgrade to @mangrovedao/mangrove-deployments v2.0.2-0
 - Upgrade to @mangrovedao/context-addresses v1.1.0

--- a/src/strategies/MangroveAmplifier.sol
+++ b/src/strategies/MangroveAmplifier.sol
@@ -12,10 +12,11 @@ import {TransferLib, AbstractRouter, RL} from "@mgv-strats/src/strategies/Mangro
 import {SmartRouter, AbstractRoutingLogic} from "@mgv-strats/src/strategies/routers/SmartRouter.sol";
 
 import {MgvLib, IERC20, OLKey, Offer, OfferDetail} from "@mgv/src/core/MgvLib.sol";
-import {TickLib, Tick} from "@mgv/lib/core/TickLib.sol";
+import {Tick} from "@mgv/lib/core/TickLib.sol";
 
-///@title MangroveAmplifier. A strat that implements "liquidity amplification". It allows offer owner to post offers on multiple markets with the same collateral.
-/// The strat is implemented such that it cannot give more than the total amplified volume even if it is approved to spend more and has access to more funds.
+///@title MangroveAmplifier. A strat that implements "liquidity amplification". It allows liquidity providers to post offers on multiple markets with the same collateral.
+/// The strat is implemented such that the whole bundle of offers should not give more than the total amplified volume even if it is approved to spend more and has access to more funds.
+/// This only holds if offer owner does not update an offer of the bundle individually and if no two offers of the same bundle are on the same offer list.
 /// e.g an amplified offer gives A for some amount of B, C or D. If taken on the (A,C) market, the (A,B) and (A,D) offers should now either:
 /// - offer the same amount of A than the residual (A,B) offer -including 0 if the offer was completely filled
 /// - or be reneging on trade (this happens only in a particular scenario in order to avoid over spending).
@@ -29,18 +30,19 @@ contract MangroveAmplifier is RenegingForwarder {
   struct BundledOffer {
     IERC20 inbound_tkn; // the inbound token of the offer in the bundle
     uint tickSpacing; // the tick spacing of the offer list in which the offer is posted
-    uint offerId; // the offer of the offer
+    uint offerId; // the id of the offer
   }
 
-  ///@notice maps a `bundleId` to a set of bundled offers
-  mapping(uint bundleId => BundledOffer[]) private __bundles;
+  ///@notice maps a bundle Id and its outbound token to a set of bundled offers
+  mapping(uint bundleId => mapping(IERC20 outbound_tkn => BundledOffer[])) private __bundles;
 
   ///@notice maps an offer list key hash and an offerId to the bundle in which this offer is.
   mapping(bytes32 olKeyHash => mapping(uint offerId => uint bundleId)) private __bundleIdOfOfferId;
 
   ///@notice logs beginning of bundle creation
   ///@param bundleId bundle identifier
-  event InitBundle(uint indexed bundleId);
+  ///@param outbound_tkn the outbound token of the bundle
+  event InitBundle(uint indexed bundleId, IERC20 indexed outbound_tkn);
 
   ///@notice logs end of bundle creation
   ///@dev to know which offer are part of the bundle one needs to track `NewOwnedOffer(olKeyHash, offerId, owner)` emitted in between `InitBundle` and `EndBundle`
@@ -67,7 +69,7 @@ contract MangroveAmplifier is RenegingForwarder {
     uint gasreq; // the gas required by this offer (gas may differ between offer because of different routing strategies)
     uint provision; // the portion of `msg.value` that should be allocated to the provision of this offer
     uint tickSpacing; // the tick spacing parameter that charaterizes the offer list to which this offer should be posted.
-    AbstractRoutingLogic inboundLogic; //the logics to manage liquidity targetting for this offer of the bundle. Use `AbstractRouter(address(0))` for simple routing.
+    AbstractRoutingLogic inboundLogic; //the logics to manage liquidity targetting for this offer of the bundle. Use `AbstractRouter(address(0))` for simple routing (to and from offer owner's address).
     IERC20 inbound_tkn; // the inbound token this offer expects
   }
 
@@ -117,7 +119,7 @@ contract MangroveAmplifier is RenegingForwarder {
   {
     HeapVarsNewBundle memory vars;
     freshBundleId = __bundleId++;
-    emit InitBundle(freshBundleId);
+    emit InitBundle(freshBundleId, fx.outbound_tkn);
 
     vars.availableProvision = msg.value;
     // fetching owner's router
@@ -126,7 +128,7 @@ contract MangroveAmplifier is RenegingForwarder {
     for (uint i; i < vr.length; i++) {
       require(vr[i].provision <= vars.availableProvision, "MgvAmplifier/NotEnoughProvisions");
       // making sure no native token remains in the strat
-      // note if `vars.provision_i` is insufficient to cover `gasreq=vr[i].gasreq` the call below will revert
+      // note if `vars.provision_i` is insufficient to cover `gasreq=vr[i].gasreq` the call to `_newOffer` below will revert
       vars.provision_i = i == vr.length - 1 ? vars.availableProvision : vr[i].provision;
       vars.olKey_i = OLKey({
         outbound_tkn: address(fx.outbound_tkn),
@@ -167,11 +169,11 @@ contract MangroveAmplifier is RenegingForwarder {
       // Updating remaining available native tokens for provisions
       vars.availableProvision -= vars.provision_i;
 
-      // pushing to storage the new bundle
+      // pushing the new bundle to storage
       vars.bundledOffer_i.tickSpacing = vr[i].tickSpacing;
       vars.bundledOffer_i.inbound_tkn = vr[i].inbound_tkn;
       __bundleIdOfOfferId[vars.olKeyHash_i][vars.bundledOffer_i.offerId] = freshBundleId;
-      __bundles[freshBundleId].push(vars.bundledOffer_i);
+      __bundles[freshBundleId][fx.outbound_tkn].push(vars.bundledOffer_i);
     }
     // Setting bundle wide expiry date if required
     // olKeyHash = bytes32(0) indicates that expiry is for the whole bundle
@@ -183,23 +185,27 @@ contract MangroveAmplifier is RenegingForwarder {
 
   ///@notice gets the offers that are bundled under the same `bundleId`
   ///@param bundleId the id of the bundle
+  ///@param outbound_tkn the outbound token of the bundle
   ///@return bundle of offers
-  function offersOf(uint bundleId) external view returns (BundledOffer[] memory) {
-    return __bundles[bundleId];
+  function offersOf(uint bundleId, IERC20 outbound_tkn) external view returns (BundledOffer[] memory) {
+    return __bundles[bundleId][outbound_tkn];
   }
 
   ///@notice retrieves bundle owner from offer owner
   ///@param bundle of offers whose owner is queried
   ///@param outbound_tkn of the bundle
-  ///@return address of the owner of the bundle
-  ///@dev call assume bundle has at least one offer.
-  function _extractOwnerOf(BundledOffer[] memory bundle, IERC20 outbound_tkn) internal view returns (address) {
-    OLKey memory olKey = OLKey({
+  ///@return owner of the bundle or address(0)
+  ///@dev call returns address(0) if bundle has no offer instead of reverting.
+  function _extractOwnerOf(BundledOffer[] memory bundle, IERC20 outbound_tkn) internal view returns (address owner) {
+    if (bundle.length == 0) return address(0);
+    bytes32 olKeyHash = OLKey({
       outbound_tkn: address(outbound_tkn),
       inbound_tkn: address(bundle[0].inbound_tkn),
       tickSpacing: bundle[0].tickSpacing
-    });
-    return (ownerOf(olKey.hash(), bundle[0].offerId));
+    }).hash();
+    uint offerId = bundle[0].offerId;
+    // We check the owner of the bundle ID by checking the owner of the first offer of the bundle
+    owner = ownerOf(olKeyHash, offerId);
   }
 
   ///@notice owner of the bundle (is owner of all its offers)
@@ -207,7 +213,7 @@ contract MangroveAmplifier is RenegingForwarder {
   ///@param outbound_tkn the outbound token of the offer bundle
   ///@return address of the owner of the bundle
   function ownerOf(uint bundleId, IERC20 outbound_tkn) external view returns (address) {
-    return _extractOwnerOf(__bundles[bundleId], outbound_tkn);
+    return _extractOwnerOf(__bundles[bundleId][outbound_tkn], outbound_tkn);
   }
 
   ///@notice updates a bundle of offers, possibly during the execution of the logic of one of them.
@@ -227,6 +233,7 @@ contract MangroveAmplifier is RenegingForwarder {
       });
       bytes32 olKeyHash_i = olKey_i.hash();
       if (skipOlKeyHash != olKeyHash_i) {
+        // view of the offer list below might revert if offer list is locked
         try MGV.offers(olKey_i, bundle[i].offerId) returns (Offer offer_i) {
           // if offer_i was previously retracted, it should no longer be considered part of the bundle.
           if (offer_i.gives() != 0) {
@@ -247,11 +254,6 @@ contract MangroveAmplifier is RenegingForwarder {
             if (reason != REPOST_SUCCESS) {
               // we do not deprovision, owner funds can be retrieved on a pull basis later on
               _retractOffer(olKey_i, bundle[i].offerId, false, false);
-            } else {
-              // set max volume back to 0 as we successfully updated outbout volume on mangrove
-              // we do not reset expiry date if offer is retracted as we won't reuse the same offerId within mangrove amplifier once reracted
-              Condition memory cond = reneging(olKeyHash_i, bundle[i].offerId);
-              if (cond.volume != 0) _setReneging(olKeyHash_i, bundle[i].offerId, cond.date, 0);
             }
           }
         } catch {
@@ -279,7 +281,7 @@ contract MangroveAmplifier is RenegingForwarder {
   ///@param outboundVolume the new volume that each offer of the bundle should now offer. Use 0 to skip volume update.
   ///@param updateExpiry whether the update also changes expiry date of the bundle
   ///@param expiryDate the new date (if `updateExpiry` is true) for the expiry of the offers of the bundle. 0 for no expiry
-  ///@dev each offer of the bundle can still be updated individually through `super.updateOffer`
+  ///@dev each offer of the bundle can still be updated individually through `super.updateOffer`.
   function updateBundle(
     uint bundleId,
     IERC20 outbound_tkn,
@@ -287,7 +289,7 @@ contract MangroveAmplifier is RenegingForwarder {
     bool updateExpiry,
     uint expiryDate // use only if `updateExpiry` is true
   ) external {
-    BundledOffer[] memory bundle = __bundles[bundleId];
+    BundledOffer[] memory bundle = __bundles[bundleId][outbound_tkn];
     require(_extractOwnerOf(bundle, outbound_tkn) == msg.sender, "MgvAmplifier/unauthorized");
     if (outboundVolume > 0) {
       _updateBundle(bundle, outbound_tkn, bytes32(0), outboundVolume);
@@ -307,16 +309,19 @@ contract MangroveAmplifier is RenegingForwarder {
     internal
     returns (uint freeWei)
   {
+    bytes32 status;
+    uint _freeWei;
+    bytes32 olKeyHash_i;
     for (uint i; i < bundle.length; i++) {
       OLKey memory olKey_i = OLKey({
         outbound_tkn: address(outbound_tkn),
         inbound_tkn: address(bundle[i].inbound_tkn),
         tickSpacing: bundle[i].tickSpacing
       });
-      bytes32 olKeyHash_i = olKey_i.hash();
+      olKeyHash_i = olKey_i.hash();
       if (skipOlKeyHash != olKeyHash_i) {
-        bytes32 status;
-        (freeWei, status) = _retractOffer(olKey_i, bundle[i].offerId, true, deprovision);
+        (_freeWei, status) = _retractOffer(olKey_i, bundle[i].offerId, true, deprovision);
+        freeWei += _freeWei;
         if (status != bytes32(0)) {
           // this only happens if offer `i` of the bundle is in a locked offer list --see `_updateBundle`
           _setReneging(olKeyHash_i, bundle[i].offerId, block.timestamp, 0);
@@ -331,9 +336,9 @@ contract MangroveAmplifier is RenegingForwarder {
   ///@return freeWei the amount of native tokens that has been sent to to msg.sender
   ///@dev offers can be retracted individually using `super.retractOffer`
   function retractBundle(uint bundleId, IERC20 outbound_tkn) external returns (uint freeWei) {
-    BundledOffer[] memory bundle = __bundles[bundleId];
+    BundledOffer[] memory bundle = __bundles[bundleId][outbound_tkn];
     require(_extractOwnerOf(bundle, outbound_tkn) == msg.sender, "MgvAmplifier/unauthorized");
-    freeWei = _retractBundle(bundle, outbound_tkn, bytes32(0), true);
+    freeWei = _retractBundle(bundle, outbound_tkn, bytes32(0), true /*deprovision*/ );
     (bool noRevert,) = msg.sender.call{value: freeWei}("");
     require(noRevert, "MgvAmplifier/weiTransferFail");
   }
@@ -350,17 +355,35 @@ contract MangroveAmplifier is RenegingForwarder {
     // this update might fail if the offer list is locked (see `_updateBundle`)
     bytes32 olKeyHash = order.olKey.hash();
     uint bundleId = __bundleIdOfOfferId[olKeyHash][order.offerId];
-    BundledOffer[] memory bundle = __bundles[bundleId];
-    // if funds are missing, the trade will fail and one should retract the bundle
-    // we also retract the bundle if there is no more outbound volume to offer (this avoids reverting of updateOffer for a too low density)
+    BundledOffer[] memory bundle = __bundles[bundleId][IERC20(order.olKey.outbound_tkn)];
+    // if funds are missing, the trade will fail and Mangrove will revert the whole trade.
+    // we retract the bundle if there is no more outbound volume to offer (this avoids reverting of updateOffer for a too low density)
     // otherwise we update the bundle to the new volume
-    uint newOutVolume = order.offer.gives() - order.takerWants;
-    if (missing == 0 && newOutVolume > 0) {
-      _updateBundle(bundle, IERC20(order.olKey.outbound_tkn), olKeyHash, newOutVolume);
-    } else {
-      // not deprovisionning to save execution gas
-      _retractBundle(bundle, IERC20(order.olKey.outbound_tkn), olKeyHash, false);
+    (uint newOutVolume,) = __residualValues__(order);
+    if (missing == 0) {
+      if (newOutVolume > 0) {
+        _updateBundle(bundle, IERC20(order.olKey.outbound_tkn), olKeyHash, newOutVolume);
+      } else {
+        // not deprovisionning to save gas
+        _retractBundle(bundle, IERC20(order.olKey.outbound_tkn), olKeyHash, false);
+      }
     }
     return missing;
+  }
+
+  /// @inheritdoc MangroveOffer
+  /// @dev Because the offer execution failed, we will retract the rest of the bundle.
+  function __posthookFallback__(MgvLib.SingleOrder calldata order, MgvLib.OrderResult calldata result)
+    internal
+    virtual
+    override
+    returns (bytes32 data)
+  {
+    bytes32 olKeyHash = order.olKey.hash();
+    uint bundleId = __bundleIdOfOfferId[olKeyHash][order.offerId];
+    BundledOffer[] memory bundle = __bundles[bundleId][IERC20(order.olKey.outbound_tkn)];
+    // not deprovisionning to save gas
+    _retractBundle(bundle, IERC20(order.olKey.outbound_tkn), olKeyHash, false);
+    return super.__posthookFallback__(order, result);
   }
 }

--- a/src/strategies/TakerOrderLib.sol
+++ b/src/strategies/TakerOrderLib.sol
@@ -2,10 +2,10 @@
 pragma solidity >=0.8.10;
 
 /// TakerOrderType is an enum that represents the type of a taker order.
-/// @param GTC Good till cancelled enforces -> This order remains active until it is either filled or canceled by the trader.
+/// @param GTC Good till cancelled -> This order remains active until it is either filled or canceled by the trader.
 /// * If an expiry date is set, This will be a GTD (Good till date) order.
 /// * this will try a market order first, and if it is partially filled but the resting order fails to be posted, it won't revert the transaction.
-/// @param GTCE Good till cancelled -> This order remains active until it is either filled or canceled by the trader. It doesn't have the restriction of avoiding immediate execution.
+/// @param GTCE Good till cancelled enforced -> This order remains active until it is either filled or canceled by the trader. It doesn't have the restriction of avoiding immediate execution.
 /// * If the resting order fails to be posted, it will revert the transaction.
 /// @param PO Post only -> This order will not execute immediately against the market.
 /// @param IOC Immediate or cancel -> This order must be filled immediately at the limit price or better. If the full order cannot be filled, the unfilled portion is canceled.
@@ -19,6 +19,7 @@ enum TakerOrderType {
   PO, // = 2
   IOC, // = 3
   FOK // = 4
+
 }
 
 using TakerOrderTypeLib for TakerOrderType global;

--- a/src/strategies/interfaces/IOfferLogic.sol
+++ b/src/strategies/interfaces/IOfferLogic.sol
@@ -51,8 +51,6 @@ interface IOfferLogic is IMaker {
   ///@param gasprice the gasprice used to compute offer's provision (use 0 to use Mangrove's gasprice)
   ///@param fund WEIs in `this` contract's balance that are used to provision the offer.
   ///@param noRevert is set to true if calling function does not wish `_newOffer` to revert on error.
-  ///@param owner the offer maker managing the offer.
-  ///@dev `owner` is required in `Forwarder` logics, when `_newOffer` or `_updateOffer` in called in a hook (`msg.sender==MGV`).
   struct OfferArgs {
     OLKey olKey;
     Tick tick;

--- a/src/strategies/routers/RouterProxyFactory.sol
+++ b/src/strategies/routers/RouterProxyFactory.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
-import {IERC20} from "@mgv/lib/IERC20.sol";
 import {RouterProxy, AbstractRouter} from "./RouterProxy.sol";
 
 /// @title Mangrove Router Proxy Factory
@@ -10,7 +9,7 @@ import {RouterProxy, AbstractRouter} from "./RouterProxy.sol";
 contract RouterProxyFactory {
   /// @notice Emitted when a new proxy is deployed through this factory.
   /// @param proxy the deployed proxy contract
-  /// @param owner The address which will be the admin and immutable owner of the newly deployed proxy.
+  /// @param owner The address which will be the admin and owner of the newly deployed proxy.
   /// @param implementation The address of the router implementation used by the proxy.
   event ProxyDeployed(RouterProxy proxy, address indexed owner, AbstractRouter indexed implementation);
 
@@ -47,7 +46,7 @@ contract RouterProxyFactory {
   /// @dev Emits a ProxyDeployed event upon successful deployment.
   ///      Note that the deployment can be initiated by any caller, on behalf of `owner`.
   function deployProxy(address owner, AbstractRouter routerImplementation) public returns (RouterProxy proxy) {
-    proxy = new RouterProxy{salt:keccak256(abi.encode(owner))}(routerImplementation);
+    proxy = new RouterProxy{salt: keccak256(abi.encode(owner))}(routerImplementation);
     // TODO: The access controlled admin must maybe be immutable (or this is a vector attack)
     // We will always link one user with a router address anyway
     AbstractRouter(address(proxy)).setAdmin(owner);

--- a/src/strategies/routers/SimpleRouter.sol
+++ b/src/strategies/routers/SimpleRouter.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
-import {IERC20} from "@mgv/lib/IERC20.sol";
 import {TransferLib} from "@mgv/lib/TransferLib.sol";
 import {AbstractRouter, RL} from "./abstract/AbstractRouter.sol";
 

--- a/src/strategies/routers/SmartRouter.sol
+++ b/src/strategies/routers/SmartRouter.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier:	MIT
 pragma solidity ^0.8.18;
 
-import {TransferLib} from "@mgv/lib/TransferLib.sol";
 import {SmartRouterStorage, AbstractRoutingLogic, IERC20} from "./SmartRouterStorage.sol";
 import {AbstractRouter, SimpleRouter, RL} from "./SimpleRouter.sol";
 

--- a/src/strategies/routers/abstract/AbstractRouter.sol
+++ b/src/strategies/routers/abstract/AbstractRouter.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.10;
 
 import {AccessControlled} from "@mgv-strats/src/strategies/utils/AccessControlled.sol";
-import {IERC20} from "@mgv/lib/IERC20.sol";
 import {RoutingOrderLib as RL} from "./RoutingOrderLib.sol";
 
 /// @title AbstractRouter

--- a/test/strategies/MgvAmplifier.gasreq.t.sol
+++ b/test/strategies/MgvAmplifier.gasreq.t.sol
@@ -231,7 +231,7 @@ contract MangroveAmplifierGasreqBaseTest is StratTest, OfferGasReqBaseTest {
   }
 
   function getFirstOfferFromBundle(uint bundleId) internal view returns (OLKey memory key, uint offerId, uint length) {
-    MangroveAmplifier.BundledOffer[] memory offers = mgvAmplifier.offersOf(bundleId);
+    MangroveAmplifier.BundledOffer[] memory offers = mgvAmplifier.offersOf(bundleId, outbound);
     key = OLKey({
       inbound_tkn: address(offers[0].inbound_tkn),
       outbound_tkn: address(outbound),
@@ -245,7 +245,7 @@ contract MangroveAmplifierGasreqBaseTest is StratTest, OfferGasReqBaseTest {
     internal
     returns (OLKey memory key, uint offerId, uint length)
   {
-    MangroveAmplifier.BundledOffer[] memory offers = mgvAmplifier.offersOf(bundleId);
+    MangroveAmplifier.BundledOffer[] memory offers = mgvAmplifier.offersOf(bundleId, outbound);
     key = OLKey({
       inbound_tkn: address(offers[0].inbound_tkn),
       outbound_tkn: address(outbound),
@@ -265,7 +265,7 @@ contract MangroveAmplifierGasreqBaseTest is StratTest, OfferGasReqBaseTest {
   }
 
   function unlockAllMarkets(uint bundleId) internal {
-    MangroveAmplifier.BundledOffer[] memory offers = mgvAmplifier.offersOf(bundleId);
+    MangroveAmplifier.BundledOffer[] memory offers = mgvAmplifier.offersOf(bundleId, outbound);
     OLKey memory toUnlock;
     toUnlock.outbound_tkn = address(outbound);
     toUnlock.tickSpacing = 1;


### PR DESCRIPTION
* fix ownerOf resulting in wrong owner

* update CHANGELOG.md

* Added `freeWei` deprovision on failed `_retractOffer` on forwarder

* solve freeWei resetting

* update CHANGELOG.md

* fixed comments

* update example

* fixed problem with cond.volume

* change to weak inequality

* fix amplifier test

* rechange mapping and revert original changes

* remove set reneging in update bundle

* move retract bundle to posthook

* fixing more comments

* fix test

* fixing comments and logging (#229)

* fixing test

* signing commit

* verifying signature

* Changelog

* updating changelog

* signature

* adding regression tests

* fix comment

* fix comment IOfferLogic

* Remove immutable keyword

* Remove unused imports

---------