### PR TITLE
docs(license): Change licenses to MIT for code mistakenly assigned BSD-2-Clause or AGPL-3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Next version
 
+- Change licenses to MIT for code mistakenly assigned BSD-2-Clause or AGPL-3.0
+
 # 2.1.0-7
 
 - feat: add `UniSwap` routing logic, manager, and univ3 logics

--- a/src/strategies/integrations/AaveMemoizer.sol
+++ b/src/strategies/integrations/AaveMemoizer.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	BSD-2-Clause
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
 import {IERC20} from "@mgv/lib/IERC20.sol";

--- a/src/strategies/offer_forwarder/RenegingForwarder.sol
+++ b/src/strategies/offer_forwarder/RenegingForwarder.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	BSD-2-Clause
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
 import {

--- a/src/strategies/routers/abstract/RoutingOrderLib.sol
+++ b/src/strategies/routers/abstract/RoutingOrderLib.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	BSD-2-Clause
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
 import {IERC20} from "@mgv/lib/IERC20.sol";

--- a/src/strategies/routing_logic/AaveLogic.sol.wip
+++ b/src/strategies/routing_logic/AaveLogic.sol.wip
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	BSD-2-Clause
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import {IERC20} from "@mgv/lib/IERC20.sol";

--- a/src/strategies/routing_logic/AaveLogicStorage.sol.wip
+++ b/src/strategies/routing_logic/AaveLogicStorage.sol.wip
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	BSD-2-Clause
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.18;
 
 import {IERC20} from "@mgv/lib/IERC20.sol";

--- a/src/strategies/routing_logic/ERC4626Logic.sol.wip
+++ b/src/strategies/routing_logic/ERC4626Logic.sol.wip
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	BSD-2-Clause
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import {SmartRouter, AbstractRouter} from "@mgv-strats/src/strategies/routers/SmartRouter.sol";

--- a/src/strategies/routing_logic/SimpleAaveLogic.sol
+++ b/src/strategies/routing_logic/SimpleAaveLogic.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	BSD-2-Clause
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import {AbstractRoutingLogic, IERC20} from "./abstract/AbstractRoutingLogic.sol";

--- a/src/strategies/routing_logic/StargateLogic.sol.wip
+++ b/src/strategies/routing_logic/StargateLogic.sol.wip
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	BSD-2-Clause
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.20;
 
 import {SmartRouter, AbstractRouter} from "@mgv-strats/src/strategies/routers/SmartRouter.sol";

--- a/test/strategies/MgvAmplifier.gasreq.t.sol
+++ b/test/strategies/MgvAmplifier.gasreq.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
 import {MangroveTest, MgvReader, TestTaker} from "@mgv/test/lib/MangroveTest.sol";

--- a/test/strategies/MgvAmplifier.t.sol
+++ b/test/strategies/MgvAmplifier.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
 import {StratTest, MgvReader, TestMaker, TestTaker, TestSender, console} from "@mgv-strats/test/lib/StratTest.sol";

--- a/test/strategies/integration/Direct.t.sol
+++ b/test/strategies/integration/Direct.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
 import {AbstractRouter, SmartRouter, RL} from "@mgv-strats/src/strategies/routers/SmartRouter.sol";

--- a/test/strategies/integration/RouterProxyFactory.t.sol
+++ b/test/strategies/integration/RouterProxyFactory.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
 import {StratTest} from "@mgv-strats/test/lib/StratTest.sol";

--- a/test/strategies/integration/SmartRouter.t.sol
+++ b/test/strategies/integration/SmartRouter.t.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier:	AGPL-3.0
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.10;
 
 import {OfferLogicTest, TestSender, IMangrove, ITesterContract, MangroveOffer} from "./abstract/OfferLogic.t.sol";


### PR DESCRIPTION
New files had mistakenly been given BSD-2-Clause or AGPL-3.0 licenses in their headers. This commit updates thse headers to use the MIT SPDX license identifier.